### PR TITLE
Update README to include latest zenodo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $ bakta_db download --output <output-path>
 or download it manually:
 
 ```bash
-$ wget https://zenodo.org/record/4337350/files/db.tar.gz
+$ wget https://zenodo.org/record/4662588/files/db.tar.gz
 $ tar -xzf db.tar.gz
 $ rm db.tar.gz
 ```


### PR DESCRIPTION
The README previously pointed to the v1 database - incompatible with
the current version (1.0) of bakta.

I downloaded the old version of the database first. Hopefully save others bandwidth by updating this link.