### PR TITLE
add conda bin path to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,6 @@ RUN source /opt/conda/bashrc && micromamba activate \
     && echo 'bakta "$@"' >> /entrypoint.sh \
     && chmod +x /entrypoint.sh 
 
+ENV PATH=/opt/conda/bin:$PATH
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
When created singularity image, `/opt/conda/bin` is not in PATH, and `bakta` commands cannot be found. This pull request added `/opt/conda/bin` to PATH in Dockerfile.