### PR TITLE
Use Pyrodigal as a faster and maintained Prodigal alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ Installation instructions, get-started and guides: Singularity [docs](https://sy
 python3 -m pip install --user bakta
 ```
 
-Bacta requires the following 3rd party software tools which must be installed and executable to use the full set of features:
+Bakta requires the following 3rd party software tools which must be installed and executable to use the full set of features:
 
 - tRNAscan-SE (2.0.8) <https://doi.org/10.1101/614032> <http://lowelab.ucsc.edu/tRNAscan-SE>
 - Aragorn (1.2.38) <http://dx.doi.org/10.1093/nar/gkh152> <http://130.235.244.92/ARAGORN>
 - INFERNAL (1.1.4) <https://dx.doi.org/10.1093%2Fbioinformatics%2Fbtt509> <http://eddylab.org/infernal>
 - PILER-CR (1.06) <https://doi.org/10.1186/1471-2105-8-18> <http://www.drive5.com/pilercr>
-- Prodigal (2.6.3) <https://dx.doi.org/10.1186%2F1471-2105-11-119> <https://github.com/hyattpd/Prodigal>
+- Pyrodigal (2.0.2) <https://doi.org/10.21105/joss.04296> <https://github.com/althonos/pyrodigal>
 - Hmmer (3.3.2) <https://doi.org/10.1093/nar/gkt263> <http://hmmer.org>
 - Diamond (2.0.14) <https://doi.org/10.1038/nmeth.3176> <https://github.com/bbuchfink/diamond>
 - Blast+ (2.12.0) <https://www.ncbi.nlm.nih.gov/pubmed/2231712> <https://blast.ncbi.nlm.nih.gov>
@@ -415,7 +415,7 @@ ncRNA (cis-regulatory) region types:
 
 ### Coding sequences
 
-The structural prediction is conducted via Prodigal and complemented by a custom detection of sORF < 30 aa.
+The structural prediction is conducted via Pyrodigal and complemented by a custom detection of sORF < 30 aa.
 
 To rapidly identify known protein sequences with exact sequence matches and to conduct a comprehensive annotations, Bakta utilizes a compact read-only SQLite database comprising protein sequence digests and pre-assigned annotations for millions of known protein sequences and clusters.
 
@@ -428,7 +428,7 @@ Conceptual terms:
 
 **CDS**:
 
-1. Prediction via Prodigal respecting sequences' completeness (distinct prediction for complete replicons and uncompleted contigs)
+1. Prediction via Pyrodigal respecting sequences' completeness (distinct prediction for complete replicons and uncompleted contigs)
 2. Discard spurious CDS via AntiFam
 3. Detect translational exceptions (selenocysteines)
 4. Detection of UPSs via MD5 digests and lookup of related IPS and PCS

--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ Bakta is *standing on the shoulder of giants* taking advantage of many great sof
 - Aragorn <https://doi.org/10.1093/nar/gkh152>
 - Infernal <https://doi.org/10.1093/bioinformatics/btt509>
 - PilerCR <https://doi.org/10.1186/1471-2105-8-18>
-- Prodigal <https://doi.org/10.1186/1471-2105-11-119>
+- Pyrodigal <https://doi.org/10.21105/joss.04296>
 - Diamond <https://doi.org/10.1038/s41592-021-01101-x>
 - BLAST+ <https://doi.org/10.1186/1471-2105-10-421>
 - HMMER <https://doi.org/10.1371/journal.pcbi.1002195>

--- a/bakta/features/cds.py
+++ b/bakta/features/cds.py
@@ -33,15 +33,14 @@ def predict(genome: dict, sequences_path: Path):
     trainings_info = None
     prodigal_metamode = genome['size'] < 20000
     if(prodigal_tf_path is None):
-        if(genome['size'] >= 20000):
-            prodigal_tf_path = cfg.tmp_path.joinpath('prodigal.tf')
-            log.info('create prodigal training file: file=%s', prodigal_tf_path)
-            closed = not genome['complete']
+        closed = not genome['complete']
+        if(not prodigal_metamode):
+            log.info('create prodigal training info object: meta=%s, closed=%s', prodigal_metamode, closed)
             orffinder = pyrodigal.OrfFinder(meta=prodigal_metamode, closed=closed)
             seqs = [c['sequence'] for c in genome['contigs']]
             trainings_info = orffinder.train(*seqs, translation_table=cfg.translation_table)
         else:
-            log.info('skip creation of prodigal training file: genome-size=%i', genome['size'])
+            log.info('skip creation of prodigal training info object: meta=%s, closed=%s', prodigal_metamode, closed)
     else:
         try:
             with prodigal_tf_path.open('rb') as fh_tf:

--- a/bakta/features/cds.py
+++ b/bakta/features/cds.py
@@ -31,7 +31,7 @@ def predict(genome: dict, sequences_path: Path):
     # create Pyrodigal trainining file if not provided by the user
     prodigal_tf_path = cfg.prodigal_tf
     trainings_info = None
-    prodigal_metamode = genome['size'] < 100000
+    prodigal_metamode = genome['size'] < pyrodigal.MIN_SINGLE_GENOME  # 20_000 bp
     if(prodigal_tf_path is None):
         closed = not genome['complete']
         if(not prodigal_metamode):

--- a/bakta/features/cds.py
+++ b/bakta/features/cds.py
@@ -31,7 +31,7 @@ def predict(genome: dict, sequences_path: Path):
     # create Pyrodigal trainining file if not provided by the user
     prodigal_tf_path = cfg.prodigal_tf
     trainings_info = None
-    prodigal_metamode = genome['size'] < 20000
+    prodigal_metamode = genome['size'] < 100000
     if(prodigal_tf_path is None):
         closed = not genome['complete']
         if(not prodigal_metamode):

--- a/bakta/features/cds.py
+++ b/bakta/features/cds.py
@@ -126,8 +126,7 @@ def create_cdss(genes, contig):
         if(first_partial_cds['strand'] == last_partial_cds['strand']
             and first_partial_cds['truncated'] != last_partial_cds['truncated']
             and first_partial_cds['start'] == 1
-            and last_partial_cds['stop'] == contig['length']
-            and contig['topology'] == bc.TOPOLOGY_CIRCULAR):
+            and last_partial_cds['stop'] == contig['length']):
             cds = last_partial_cds
             cds['stop'] = first_partial_cds['stop']
             if(last_partial_cds['truncated'] == bc.FEATURE_END_3_PRIME):

--- a/bakta/features/cds.py
+++ b/bakta/features/cds.py
@@ -67,7 +67,7 @@ def predict(genome: dict, sequences_path: Path):
     # predict genes on circular replicons (chromosomes/plasmids)
     circular_sequences = {c['id'] : c for c in genome['contigs'] if c['topology'] == bc.TOPOLOGY_CIRCULAR}
     if(len(circular_sequences) > 0):
-        orffinder = pyrodigal.OrfFinder(trainings_info, meta=prodigal_metamode, closed=True, mask=True)
+        orffinder = pyrodigal.OrfFinder(trainings_info, meta=prodigal_metamode, closed=False, mask=True)
         future_per_contig = {}
         with cf.ProcessPoolExecutor(max_workers=cfg.threads) as tpe:
             for id, sequence in circular_sequences.items():

--- a/bakta/utils.py
+++ b/bakta/utils.py
@@ -42,7 +42,6 @@ DEPENDENCY_TRNASCAN = (Version(2, 0, 8), Version(VERSION_MAX_DIGIT, VERSION_MAX_
 DEPENDENCY_ARAGORN = (Version(1, 2, 38), Version(VERSION_MAX_DIGIT, VERSION_MAX_DIGIT, VERSION_MAX_DIGIT), VERSION_REGEX, ('aragorn', '-h'), ['skip-tmrna'])
 DEPENDENCY_CMSCAN = (Version(1, 1, 4), Version(VERSION_MAX_DIGIT, VERSION_MAX_DIGIT, VERSION_MAX_DIGIT), VERSION_REGEX, ('cmscan', '-h'), ['--skip-rrna', '--skip-ncrna', '--skip-ncrna-region'])
 DEPENDENCY_PILERCR = (Version(1, 6), Version(VERSION_MAX_DIGIT, VERSION_MAX_DIGIT, VERSION_MAX_DIGIT), VERSION_REGEX, ('pilercr', '-options'), ['--skip-crispr'])
-DEPENDENCY_PRODIGAL = (Version(2, 6, 3), Version(VERSION_MAX_DIGIT, VERSION_MAX_DIGIT, VERSION_MAX_DIGIT), VERSION_REGEX, ('prodigal', '-v'), ['--skip-cds'])
 DEPENDENCY_HMMSEARCH = (Version(3, 3, 2), Version(VERSION_MAX_DIGIT, VERSION_MAX_DIGIT, VERSION_MAX_DIGIT), VERSION_REGEX, ('hmmsearch', '-h'), ['--skip-cds', '--skip-sorf'])
 DEPENDENCY_DIAMOND = (Version(2, 0, 14), Version(VERSION_MAX_DIGIT, VERSION_MAX_DIGIT, VERSION_MAX_DIGIT), VERSION_REGEX, ('diamond', 'help'), ['--skip-cds', '--skip-sorf'])
 DEPENDENCY_DEEPSIG = (Version(1, 2, 5), Version(VERSION_MAX_DIGIT, VERSION_MAX_DIGIT, VERSION_MAX_DIGIT), VERSION_REGEX, ('deepsig', '--version'), ['--gram ?'])
@@ -220,7 +219,6 @@ def test_dependencies():
         test_dependency(DEPENDENCY_PILERCR)
 
     if(cfg.skip_cds is not None and cfg.skip_cds is False):
-        test_dependency(DEPENDENCY_PRODIGAL)
         test_dependency(DEPENDENCY_AMRFINDERPLUS)
 
         # test if AMRFinderPlus db is installed

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - aragorn>=1.2.38
   - infernal>=1.1.4
   - piler-cr
-  - prodigal>=2.6.3
+  - pyrodigal>=1.1.2
   - hmmer>=3.3.2
   - diamond>=2.0.14
   - blast>=2.12.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,11 +8,11 @@ dependencies:
   - xopen>=1.1.0
   - requests>=2.25.1
   - alive-progress==1.6.2
+  - pyrodigal>=2.0.2
   - trnascan-se>=2.0.8
   - aragorn>=1.2.38
   - infernal>=1.1.4
   - piler-cr
-  - pyrodigal>=1.1.2
   - hmmer>=3.3.2
   - diamond>=2.0.14
   - blast>=2.12.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'xopen >= 1.1.0',
         'requests >= 2.25.1',
         'alive-progress == 1.6.2',
-        'pyrodigal >= 1.1.2'
+        'pyrodigal >= 2.0.2'
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'biopython >= 1.78',
         'xopen >= 1.1.0',
         'requests >= 2.25.1',
-        'alive-progress == 1.6.2'
+        'alive-progress == 1.6.2',
+        'pyrodigal >= 1.1.2'
     ],
     entry_points={
         'console_scripts': [

--- a/test/test_bakta.py
+++ b/test/test_bakta.py
@@ -106,7 +106,7 @@ def test_bakta_genome(tmpdir):
 
     output_path = tmpdir_path.joinpath('test.tsv')
     feature_count, feature_counts = count_features(output_path)
-    assert feature_count == 5549
+    assert feature_count == 5551
     feature_counts_expected = {
         'tRNA': 107,
         'tmRNA': 1,
@@ -118,7 +118,7 @@ def test_bakta_genome(tmpdir):
         'oriV': 0,
         'oriC': 0,
         'oriT': 0,
-        'cds': 5373
+        'cds': 5375
     }
     for type in feature_counts:
         assert feature_counts[type] == feature_counts_expected[type]

--- a/test/test_bakta.py
+++ b/test/test_bakta.py
@@ -106,7 +106,7 @@ def test_bakta_genome(tmpdir):
 
     output_path = tmpdir_path.joinpath('test.tsv')
     feature_count, feature_counts = count_features(output_path)
-    assert feature_count == 5551
+    assert feature_count == 5549
     feature_counts_expected = {
         'tRNA': 107,
         'tmRNA': 1,
@@ -118,7 +118,7 @@ def test_bakta_genome(tmpdir):
         'oriV': 0,
         'oriC': 0,
         'oriT': 0,
-        'cds': 5375
+        'cds': 5373
     }
     for type in feature_counts:
         assert feature_counts[type] == feature_counts_expected[type]


### PR DESCRIPTION
Since release [2.0.0](https://github.com/althonos/pyrodigal/releases/tag/v2.0.0) [Pyrodigal](https://github.com/althonos/pyrodigal) is a reliable, faster and most important actively maintained version of or successor to Prodigal.

Due to @jhahnfeld 's [comparison](https://github.com/jhahnfeld/prodigal-pyrodigal-comparison) (Kudos!) we're confident enough to replace the tested and well-accepted Prodigal by Pyrodigal.

Further information:
- Backward compatibility of Prodigal training files should be given
- Slightly shorter overall runtimes due to parallel Python in-memory gene predictions in contrast to Prodigal as an external process