### PR TITLE
Fix wrong order for family and given name in Citation.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,8 +31,8 @@ preferred-citation:
       given-names: Marius Alfred
       orcid: https://orcid.org/0000-0001-5130-546X
     -
-      family-names: Sebastian
-      given-names: Beyvers
+      family-names: Beyvers
+      given-names: Sebastian
       orcid: https://orcid.org/0000-0002-9747-7096
     -
       family-names: Blom


### PR DESCRIPTION
Just a small fix, my family and given name were in the wrong order in the Citation.cff, resulting in the following wrong citation on GitHub:

```
Schwengers, O., Jelonek, L., Dieckmann, M. A., Sebastian, B., Blom, J., & Goesmann, A. (2021). 
Bakta: rapid & standardized annotation of bacterial genomes via alignment-free sequence identification. 
Microbial Genomics. https://doi.org/10.1099/mgen.0.000685
```

`Sebastian, B.` vs. `Beyvers, S.`

BR
