### PR TITLE
refactor expert systems

### DIFF
--- a/bakta/expert/amrfinder.py
+++ b/bakta/expert/amrfinder.py
@@ -56,29 +56,30 @@ def search(cdss: Sequence[dict], cds_fasta_path: Path):
                     cov_ref_seq, ident_ref_seq, alignment_length, accession_closest_seq, name_closest_seq, hmm_id, hmm_description
                 ) = line.split('\t')
                 cds = cds_by_hexdigest[aa_identifier]
-                expert_hit = {
+                hit = {
+                    'type': 'amrfinder',
                     'rank': 95,
                     'gene': gene if gene != '' else None,
                     'product': product,
                     'method': method
                 }
                 if(method.lower() != 'hmm'):
-                    expert_hit['query_cov'] = int(alignment_length) / len(cds['aa'])
+                    hit['query_cov'] = int(alignment_length) / len(cds['aa'])
                     model_cov = float(cov_ref_seq) / 100
-                    expert_hit['model_cov'] = model_cov
+                    hit['model_cov'] = model_cov
                     identity = float(ident_ref_seq) / 100
-                    expert_hit['identity'] = identity
-                    expert_hit['id'] = accession_closest_seq
-                    expert_hit['db_xrefs'] = [f'{bc.DB_XREF_NCBI_PROTEIN}:{accession_closest_seq}']
+                    hit['identity'] = identity
+                    hit['id'] = accession_closest_seq
+                    hit['db_xrefs'] = [f'{bc.DB_XREF_NCBI_PROTEIN}:{accession_closest_seq}']
                 else:
                     model_cov = 0
                     identity = 0
-                    expert_hit['id'] = hmm_id
-                    expert_hit['db_xrefs'] = [f'{bc.DB_XREF_NCBI_FAMILIES}:{hmm_id}']
+                    hit['id'] = hmm_id
+                    hit['db_xrefs'] = [f'{bc.DB_XREF_NCBI_FAMILIES}:{hmm_id}']
 
                 if('expert' not in cds):
-                    cds['expert'] = {}
-                cds['expert']['amrfinder'] = expert_hit
+                    cds['expert'] = []
+                cds['expert'].append(hit)
                 log.debug(
                     'hit: gene=%s, product=%s, method=%s, target-cov=%0.3f, identity=%0.3f, contig=%s, start=%i, stop=%i, strand=%s',
                     gene, product, method, model_cov, identity, cds['contig'], cds['start'], cds['stop'], cds['strand']

--- a/bakta/expert/protein_sequences.py
+++ b/bakta/expert/protein_sequences.py
@@ -64,7 +64,8 @@ def search(cdss: Sequence[dict], cds_fasta_path: Path, expert_system: str, db_pa
             min_query_cov = float(min_query_cov) / 100
             min_model_cov = float(min_model_cov) / 100
             if(query_cov >= min_query_cov and model_cov >= min_model_cov and identity >= min_identity):
-                expert_hit = {
+                hit = {
+                    'type': expert_system,
                     'source': source,
                     'rank': rank,
                     'id': model_id,
@@ -78,13 +79,13 @@ def search(cdss: Sequence[dict], cds_fasta_path: Path, expert_system: str, db_pa
                     'db_xrefs': [] if dbxrefs == '' else dbxrefs.split(',')
                 }
                 if(expert_system == 'user_proteins'):
-                    expert_hit['db_xrefs'].append(f'UserProtein:{model_id}')
+                    hit['db_xrefs'].append(f'UserProtein:{model_id}')
                 if('expert' not in cds):
-                    cds['expert'] = {}
-                cds['expert'][expert_system] = expert_hit
+                    cds['expert'] = []
+                cds['expert'].append(hit)
                 log.debug(
-                    'hit: contig=%s, start=%i, stop=%i, strand=%s, source=%s, rank=%i, query-cov=%0.3f, model-cov=%0.3f, identity=%0.3f, gene=%s, product=%s, evalue=%1.1e, bitscore=%f',
-                    cds['contig'], cds['start'], cds['stop'], cds['strand'], source, rank, query_cov, model_cov, identity, gene, product, evalue, bitscore
+                    'hit: source=%s, rank=%i, contig=%s, start=%i, stop=%i, strand=%s, query-cov=%0.3f, model-cov=%0.3f, identity=%0.3f, gene=%s, product=%s, evalue=%1.1e, bitscore=%f',
+                    source, rank, cds['contig'], cds['start'], cds['stop'], cds['strand'], query_cov, model_cov, identity, gene, product, evalue, bitscore
                 )
                 cds_found.add(aa_identifier)
 

--- a/bakta/features/annotation.py
+++ b/bakta/features/annotation.py
@@ -42,7 +42,7 @@ def combine_annotation(feature: dict):
     ips = feature.get('ips', None)
     psc = feature.get('psc', None)
     pscc = feature.get('pscc', None)
-    expert = feature.get('expert', None)
+    expert_hits = feature.get('expert', [])
 
     gene = None
     genes = set()
@@ -101,22 +101,18 @@ def combine_annotation(feature: dict):
             product = ips_product
         for db_xref in ips['db_xrefs']:
             db_xrefs.add(db_xref)
-    if(expert):
-        rank = 0
-        for expert_system, expert_hit in expert.items():
-            expert_rank = expert_hit['rank']
-            if(expert_rank > rank):
-                expert_genes = expert_hit.get('gene', None)
-                if(expert_genes):
-                    expert_genes = expert_genes.replace('/', ',').split(',')
-                    genes.update(expert_genes)
-                    gene = expert_genes[0]
-                product = expert_hit.get('product', None)
-                expert_db_xrefs = expert_hit.get('db_xrefs', None)
-                if(expert_db_xrefs):
-                    for expert_db_xref in expert_db_xrefs:
-                        db_xrefs.add(expert_db_xref)
-                rank = expert_rank
+    rank = 0
+    for hit in expert_hits:
+        db_xrefs.update(hit.get('db_xrefs', []))
+        expert_rank = hit['rank']
+        if(expert_rank > rank):
+            expert_genes = hit.get('gene', None)
+            if(expert_genes):
+                expert_genes = expert_genes.replace('/', ',').split(',')
+                genes.update(expert_genes)
+                gene = expert_genes[0]
+            product = hit.get('product', None)
+            rank = expert_rank
 
     if(product):
         product = revise_cds_product(product)

--- a/test/test_user_proteins.py
+++ b/test/test_user_proteins.py
@@ -166,10 +166,9 @@ def test_user_proteins(parameters, tmpdir):
     ec_annotated = 0
     user_prot_feats = []
     for feat in results['features']:
-        if('expert' in feat and 'user_proteins' in feat['expert']):
-            user_prot_feats.append(feat)
-        for db_xref in feat['db_xrefs']:
-            if('EC' in db_xref):
-                ec_annotated += 1
+        for expert in feat.get('expert', []):
+            if(expert['type'] == 'user_proteins'):
+                user_prot_feats.append(feat)
+                ec_annotated += len([x for x in feat['db_xrefs'] if 'EC' in x])
     assert ec_annotated == 1
     assert len(user_prot_feats) == 1


### PR DESCRIPTION
As brought  up in #198, currently only the best expert hit is reported in the `expert hits` section in the JSON result file. To fix this, we need to refactor this result section which will introduce breaking changes. Therefore, we cannot release this within a `patch` release, but postpone it to the next `minor` release `v1.9.0`.