### PR TITLE
tweaked to allow biopython 1.78

### DIFF
--- a/bakta/plot.py
+++ b/bakta/plot.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import yaml
 
 from Bio import SeqUtils
+import Bio as bp
 
 import bakta
 import bakta.utils as bu
@@ -334,7 +335,10 @@ def write_gc_content_skew(contigs, circos_path, colors):
     gc_skews = []
     max_gc = 0
     max_gc_skew = 0
-    gc_mean = SeqUtils.gc_fraction(''.join([c['sequence'] for c in contigs]))
+    if float(bp.__version__) >= 1.80:
+        gc_mean = SeqUtils.gc_fraction(''.join([c['sequence'] for c in contigs]))
+    else:
+        gc_mean = SeqUtils.GC(''.join([c['sequence'] for c in contigs])) / 100
     for contig in contigs:
         seq = contig['sequence']
         for w in range(0, len(seq), step_size):
@@ -345,7 +349,10 @@ def write_gc_content_skew(contigs, circos_path, colors):
             if stop > len(seq):
                 stop -= len(seq)
             subseq = seq[start:stop] if start < stop else seq[start:] + seq[:stop]
-            gc_value = gc_mean - SeqUtils.gc_fraction(subseq)
+            if float(bp.__version__) >= 1.80:
+                gc_value = gc_mean - SeqUtils.gc_fraction(subseq)
+            else:
+                gc_value = gc_mean - (SeqUtils.GC(subseq) / 100)
             if max_gc < abs(gc_value):
                 max_gc = abs(gc_value)
             gc_color = colors['gc-positive'] if gc_value >= 0 else colors['gc-negative']

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - biopython>=1.80
+  - biopython>=1.78
   - xopen>=1.1.0
   - requests>=2.25.1
   - alive-progress>=3.0.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     include_package_data=False,
     zip_safe=False,
     install_requires=[
-        'biopython >= 1.80',
+        'biopython >= 1.78',
         'xopen >= 1.1.0',
         'requests >= 2.25.1',
         'alive-progress >= 3.0.1',


### PR DESCRIPTION
This pull request updates bakta to allow for biopython of either 1.78-1.79 or >= 1.80. It includes a check in the plot.py for the biopython version. I tested it locally with biopython 1.78 and the run succeeded and produced the correct plot.