### PR TITLE
Replace hmmer with py hmmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Bakta requires the following 3rd party software tools which must be installed an
 - INFERNAL (1.1.4) <https://dx.doi.org/10.1093%2Fbioinformatics%2Fbtt509> <http://eddylab.org/infernal>
 - PILER-CR (1.06) <https://doi.org/10.1186/1471-2105-8-18> <http://www.drive5.com/pilercr>
 - Pyrodigal (2.0.2) <https://doi.org/10.21105/joss.04296> <https://github.com/althonos/pyrodigal>
-- PyHMMER (0.8.2) <https://doi.org/10.21105/joss.04296> <https://github.com/althonos/pyhmmer>
+- PyHMMER (0.8.1) <https://doi.org/10.21105/joss.04296> <https://github.com/althonos/pyhmmer>
 - Diamond (2.0.14) <https://doi.org/10.1038/nmeth.3176> <https://github.com/bbuchfink/diamond>
 - Blast+ (2.12.0) <https://www.ncbi.nlm.nih.gov/pubmed/2231712> <https://blast.ncbi.nlm.nih.gov>
 - AMRFinderPlus (3.10.23) <https://github.com/ncbi/amr>

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Bakta requires the following 3rd party software tools which must be installed an
 - INFERNAL (1.1.4) <https://dx.doi.org/10.1093%2Fbioinformatics%2Fbtt509> <http://eddylab.org/infernal>
 - PILER-CR (1.06) <https://doi.org/10.1186/1471-2105-8-18> <http://www.drive5.com/pilercr>
 - Pyrodigal (2.0.2) <https://doi.org/10.21105/joss.04296> <https://github.com/althonos/pyrodigal>
-- Hmmer (3.3.2) <https://doi.org/10.1093/nar/gkt263> <http://hmmer.org>
+- PyHMMER (0.8.2) <https://doi.org/10.21105/joss.04296> <https://github.com/althonos/pyhmmer>
 - Diamond (2.0.14) <https://doi.org/10.1038/nmeth.3176> <https://github.com/bbuchfink/diamond>
 - Blast+ (2.12.0) <https://www.ncbi.nlm.nih.gov/pubmed/2231712> <https://blast.ncbi.nlm.nih.gov>
 - AMRFinderPlus (3.10.23) <https://github.com/ncbi/amr>
@@ -738,6 +738,7 @@ Bakta is *standing on the shoulder of giants* taking advantage of many great sof
 - Pyrodigal <https://doi.org/10.21105/joss.04296>
 - Diamond <https://doi.org/10.1038/s41592-021-01101-x>
 - BLAST+ <https://doi.org/10.1186/1471-2105-10-421>
+- PyHMMER <https://doi.org/10.21105/joss.04296>
 - HMMER <https://doi.org/10.1371/journal.pcbi.1002195>
 - AMRFinderPlus <https://doi.org/10.1038/s41598-021-91456-0>
 - DeepSig <https://doi.org/10.1093/bioinformatics/btx818>

--- a/bakta/main.py
+++ b/bakta/main.py
@@ -230,9 +230,7 @@ def main():
 
         if(len(cdss) > 0):
             log.debug('detect spurious CDS')
-            cds_aa_path = cfg.tmp_path.joinpath('cds.spurious.faa')
-            orf.write_internal_faa(cdss, cds_aa_path)
-            discarded_cdss = orf.detect_spurious(cdss, cds_aa_path)
+            discarded_cdss = orf.detect_spurious(cdss)
             print(f'\tdiscarded spurious: {len(discarded_cdss)}')
             cdss = [cds for cds in cdss if 'discarded' not in cds]
         
@@ -339,9 +337,7 @@ def main():
 
         if(len(sorfs) > 0):
             log.debug('detect spurious sORF')
-            sorf_aa_path = cfg.tmp_path.joinpath('sorf.spurious.faa')
-            orf.write_internal_faa(sorfs, sorf_aa_path)
-            discarded_sorfs = orf.detect_spurious(sorfs, sorf_aa_path)
+            discarded_sorfs = orf.detect_spurious(sorfs)
             print(f'\tdiscarded spurious: {len(discarded_sorfs)}')
             sorfs = [sorf for sorf in sorfs if 'discarded' not in sorf]
 

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - aragorn>=1.2.41
   - infernal>=1.1.4
   - piler-cr
-  - hmmer>=3.3.2
+  - pyhmmer>=0.8.2
   - diamond>=2.0.14
   - blast>=2.12.0
   - ncbi-amrfinderplus>=3.11.2

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - aragorn>=1.2.41
   - infernal>=1.1.4
   - piler-cr
-  - pyhmmer>=0.8.2
+  - pyhmmer>=0.8.1
   - diamond>=2.0.14
   - blast>=2.12.0
   - ncbi-amrfinderplus>=3.11.2

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ setup(
         'requests >= 2.25.1',
         'alive-progress >= 3.0.1',
         'PyYAML >= 6.0',
-        'pyrodigal >= 2.1.0'
+        'pyrodigal >= 2.1.0',
+        'pyhmmer >= 0.8.1'
     ],
     entry_points={
         'console_scripts': [

--- a/test/test-genomes.nf
+++ b/test/test-genomes.nf
@@ -65,6 +65,6 @@ process bakta {
     script:
     completeOption = complete ? '--complete' : ''
     """
-    ${baseDir}/../bin/bakta --db ${pathDb} --verbose --prefix ${accession} --genus ${genus} --species "${species}" --strain "${strain}" --keep-contig-headers --threads ${task.cpus} ${completeOption} assembly.fna
+    ${baseDir}/../bin/bakta --force --db ${pathDb} --verbose --prefix ${accession} --genus ${genus} --species "${species}" --strain "${strain}" --keep-contig-headers --threads ${task.cpus} ${completeOption} assembly.fna
     """
 }

--- a/test/test-genomes.nf
+++ b/test/test-genomes.nf
@@ -65,6 +65,6 @@ process bakta {
     script:
     completeOption = complete ? '--complete' : ''
     """
-    ${baseDir}/../bin/bakta --force --db ${pathDb} --verbose --prefix ${accession} --genus ${genus} --species "${species}" --strain "${strain}" --keep-contig-headers --threads ${task.cpus} ${completeOption} assembly.fna
+    ${baseDir}/../bin/bakta --db ${pathDb} --verbose --prefix ${accession} --genus ${genus} --species "${species}" --strain "${strain}" --keep-contig-headers --threads ${task.cpus} ${completeOption} assembly.fna
     """
 }


### PR DESCRIPTION
[PyHMMER](https://github.com/althonos/pyhmmer) provides bindings to HMMER3 and allows functions like `hmmsearch` to be used directly in Python without temporary files.
It is faster compared to HMMER because of a new parallelization model and provides identical results.