### PR TITLE
Replace setup-miniconda by setup-micromamba GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,14 @@ jobs:
     #   run: mamba install numpy=1.23 keras=2.4.3 tensorflow=2.2.0 chardet deepsig
     - name: Install PyTest
       run: mamba install pytest
+      shell: bash -l {0}
     - name: Mamba info
       run: |
         mamba info
         mamba list
         printenv | sort
+      shell: bash -l {0}
     - name: Run PyTest
       if: ${{ matrix.os == 'ubuntu-latest'  ||  matrix.python-version == '3.10'}}
       run: pytest
+      shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,12 @@ jobs:
     #   if: ${{ matrix.os == 'ubuntu-latest'  &&  matrix.python-version == '3.8'}}
     #   run: mamba install numpy=1.23 keras=2.4.3 tensorflow=2.2.0 chardet deepsig
     - name: Install PyTest
-      run: mamba install pytest
+      run: micromamba install pytest
       shell: bash -l {0}
     - name: Mamba info
       run: |
-        mamba info
-        mamba list
+        micromamba info
+        micromamba list
         printenv | sort
       shell: bash -l {0}
     - name: Run PyTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         auto-update-conda: false
         python-version: ${{ matrix.python-version }}
         miniconda-version: "latest"
-        mamba-version: "1.4.3"
+        mamba-version: "1.4.4"
         channels: conda-forge,bioconda
         channel-priority: true
         auto-activate-base: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         auto-update-conda: false
         python-version: ${{ matrix.python-version }}
         miniconda-version: "latest"
-        mamba-version: "1.4.9"
+        mamba-version: "1.4.3"
         channels: conda-forge,bioconda
         channel-priority: true
         auto-activate-base: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       - 'README.md'
 jobs:
   build:
-    name: test (${{ matrix.os }}, ${{ matrix.python-version }})
+    name: Test (${{ matrix.os }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,27 +24,29 @@ jobs:
         python-version: ['3.10'] # ['3.8', '3.10']
     steps:
     - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: mamba-org/setup-micromamba@v1
       with:
-        auto-update-conda: false
-        python-version: ${{ matrix.python-version }}
-        miniconda-version: "latest"
-        mamba-version: "1.4.4"
-        channels: conda-forge,bioconda
-        channel-priority: true
-        auto-activate-base: false
-        environment-file: environment.yml
-        activate-environment: bakta
+        micromamba-version: 'latest'
+        environment-name: 'bakta'
+        environment-file: 'environment.yml'
+        create-args: python=${{ matrix.python-version }}
+        condarc: |
+          channels:
+            - conda-forge
+            - bioconda
+        init-shell: bash -l {0}
+        cache-environment: true
+        cache-downloads: true
+        post-cleanup: 'all'
     # - name: Install DeepSig
     #   if: ${{ matrix.os == 'ubuntu-latest'  &&  matrix.python-version == '3.8'}}
-    #   run: conda install numpy=1.23 keras=2.4.3 tensorflow=2.2.0 chardet deepsig
+    #   run: mamba install numpy=1.23 keras=2.4.3 tensorflow=2.2.0 chardet deepsig
     - name: Install PyTest
-      run: conda install pytest
-    - name: Conda info
+      run: mamba install pytest
+    - name: Mamba info
       run: |
-        conda info
-        conda list
-        conda config --show
+        mamba info
+        mamba list
         printenv | sort
     - name: Run PyTest
       if: ${{ matrix.os == 'ubuntu-latest'  ||  matrix.python-version == '3.10'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           channels:
             - conda-forge
             - bioconda
-        init-shell: bash -l {0}
+        init-shell: bash
         cache-environment: true
         cache-downloads: true
         post-cleanup: 'all'


### PR DESCRIPTION
To solve a Python 'ImportError' (https://github.com/oschwengers/bakta/actions/runs/5752384837/job/15739255733), 
[`conda-forge/setup-miniconda`](https://github.com/conda-incubator/setup-miniconda) was replaced by [`mamba-org/setup-micromamba@v1`](https://github.com/mamba-org/setup-micromamba).