### PR TITLE
fix(create_cdss): Handle different translation tables in meta mode

### DIFF
--- a/bakta/features/cds.py
+++ b/bakta/features/cds.py
@@ -119,7 +119,13 @@ def create_cdss(genes, contig):
             partial_cdss_per_sequence.append(cds)
         else:
             cdss_per_sequence.append(cds)
-        aa = gene.translate(translation_table=cfg.translation_table).upper()
+
+        # In meta mode, let pyrodigal use the translation table the gene was predicted with
+        if cfg.meta:
+            aa = gene.translate(translation_table=None).upper()
+        else:
+            aa = gene.translate(translation_table=cfg.translation_table).upper()
+        
         if('truncated' not in cds or cds['truncated'] == bc.FEATURE_END_5_PRIME):
             aa = aa[:-1]  # discard trailing asterisk
         cds['aa'] = aa


### PR DESCRIPTION
Update CDS creation process to use the translation table that pyrodigal 
used for gene prediction in meta mode. This ensures accurate translation 
of genes across different genetic codes.

Previously, metagenome contigs predicted with translation table 4 were 
incorrectly translated with table 11, resulting in amino acid sequences 
with numerous internal stop codons ('*').