### PR TITLE
Fix CRISPR parser

### DIFF
--- a/bakta/features/crispr.py
+++ b/bakta/features/crispr.py
@@ -11,7 +11,7 @@ import bakta.so as so
 import bakta.utils as bu
 
 
-RE_CRISPR = re.compile(r'(\d{1,8})\s+(\d{2})\s+(\d{1,3}\.\d)\s+(?:(\d{1})\s+)?([ATGCN]+)?\s+([ATGCN\.-]+)\s*(?:([ATGCN]+))?')
+RE_CRISPR = re.compile(r'(\d{1,8})\s+(\d{2})\s+(\d{1,3}\.\d)\s+(?:(\d{1,2})\s+)?([ATGCN]+)?\s+([ATGCN\.-]+)\s*(?:([ATGCN]+))?')
 
 
 log = logging.getLogger('CRISPR')

--- a/bakta/features/crispr.py
+++ b/bakta/features/crispr.py
@@ -98,7 +98,7 @@ def predict_crispr(genome: dict, contigs_path: Path):
                                 spacer_length = len(spacer_seq)
                                 crispr_spacer = OrderedDict()
                                 crispr_spacer['strand'] = bc.STRAND_UNKNOWN
-                                crispr_spacer['start'] = position + repeat_length  - gap_count
+                                crispr_spacer['start'] = position + repeat_length - gap_count
                                 crispr_spacer['stop'] = position + repeat_length + spacer_length - 1 - gap_count
                                 crispr_spacer['sequence'] = spacer_seq
                                 crispr_array['spacers'].append(crispr_spacer)

--- a/bakta/features/crispr.py
+++ b/bakta/features/crispr.py
@@ -11,7 +11,7 @@ import bakta.so as so
 import bakta.utils as bu
 
 
-RE_CRISPR = re.compile(r'(\d{1,8})\s+(\d{2})\s+(\d{1,3}\.\d)\s+(?:(\d{2})\s+)?([ATGCN]+)?\s+([ATGCN\.-]+)\s*(?:([ATGCN]+))?')
+RE_CRISPR = re.compile(r'(\d{1,8})\s+(\d{2})\s+(\d{1,3}\.\d)\s+(?:(\d{1})\s+)?([ATGCN]+)?\s+([ATGCN\.-]+)\s*(?:([ATGCN]+))?')
 
 
 log = logging.getLogger('CRISPR')


### PR DESCRIPTION
We wrongly assumed that  a double digit number is correct for matching the CRISPR spacer length. However, there are shorter spacer lengths reported #299. Hence, we have to fix this by relaxing the regex to a single digit CRISPR spacer length.