### PR TITLE
Revise truncated pseudo attributes

### DIFF
--- a/bakta/constants.py
+++ b/bakta/constants.py
@@ -131,6 +131,7 @@ INSDC_FEATURE_REPEAT_TYPE = 'rpt_type'  # /rpt_type=<repeat_type>  # 'direct'
 INSDC_FEATURE_REPEAT_UNIT_RANGE = 'rpt_unit_range'  # /rpt_unit_range=<base_range>
 INSDC_FEATURE_REPEAT_UNIT_SEQ = 'rpt_unit_seq'  # /rpt_unit_seq="text"
 INSDC_FEATURE_CDS = 'CDS'
+INSDC_FEATURE_PSEUDO = 'pseudo'
 INSDC_FEATURE_PSEUDOGENE = 'pseudogene'
 INSDC_FEATURE_PSEUDOGENE_TYPE_UNITARY = 'unitary'
 INSDC_FEATURE_PSEUDOGENE_TYPE_UNPROCESSED = 'unprocessed'

--- a/bakta/expert/protein_sequences.py
+++ b/bakta/expert/protein_sequences.py
@@ -106,7 +106,7 @@ def write_user_protein_sequences(aa_fasta_path: Path):
         with xopen(str(cfg.user_proteins), threads=0) as fh_in:
             for record in SeqIO.parse(fh_in, 'genbank'):
                 for feature in record.features:
-                    if(feature.type.lower() == 'cds'  and  'pseudo' not in feature.qualifiers and  bc.INSDC_FEATURE_PSEUDOGENE not in feature.qualifiers):
+                    if(feature.type.lower() == 'cds'  and  bc.INSDC_FEATURE_PSEUDO not in feature.qualifiers  and  bc.INSDC_FEATURE_PSEUDOGENE not in feature.qualifiers):
                         user_proteins.append(parse_user_protein_sequences_genbank(feature))
     except Exception as e:
         log.error('provided user proteins file GenBank format not valid!', exc_info=True)

--- a/bakta/features/cds.py
+++ b/bakta/features/cds.py
@@ -745,14 +745,11 @@ def detect_pseudogenes(candidates: Sequence[dict], cdss: Sequence[dict], genome:
                         pseudogene['description'] = f"{effects}. {causes}" if effects != '' else causes
 
                         if bc.FEATURE_END_5_PRIME in directions and bc.FEATURE_END_3_PRIME in directions:
-                            truncation = bc.FEATURE_END_BOTH
+                            cds['truncated'] = bc.FEATURE_END_BOTH
                         elif bc.FEATURE_END_5_PRIME in directions:
-                            truncation = bc.FEATURE_END_5_PRIME if cds['strand'] == bc.STRAND_FORWARD else bc.FEATURE_END_3_PRIME
+                            cds['truncated'] = bc.FEATURE_END_5_PRIME if cds['strand'] == bc.STRAND_FORWARD else bc.FEATURE_END_3_PRIME
                         elif bc.FEATURE_END_3_PRIME in directions:
-                            truncation = bc.FEATURE_END_3_PRIME if cds['strand'] == bc.STRAND_FORWARD else bc.FEATURE_END_5_PRIME
-                        cds['truncated'] = truncation
-
-                        cds['pseudo'] = True
+                            cds['truncated'] = bc.FEATURE_END_3_PRIME if cds['strand'] == bc.STRAND_FORWARD else bc.FEATURE_END_5_PRIME
                         cds[bc.PSEUDOGENE] = pseudogene
                         cds.pop('hypothetical')
                         pseudogenes.append(cds)

--- a/bakta/features/cds.py
+++ b/bakta/features/cds.py
@@ -282,7 +282,7 @@ def import_user_cdss(genome: dict, import_path: Path):
                                     contig['id'], feature.location.start, feature.location.end, strand
                                 )
                                 continue
-                            elif('pseudo' in feature.qualifiers  or  bc.INSDC_FEATURE_PSEUDOGENE in feature.qualifiers):
+                            elif(bc.INSDC_FEATURE_PSEUDO in feature.qualifiers  or  bc.INSDC_FEATURE_PSEUDOGENE in feature.qualifiers):
                                 log.debug(
                                     'skip user-provided CDS: reason=pseudo, contig=%s, start=%i, stop=%i, strand=%s',
                                     contig['id'], feature.location.start, feature.location.end, strand

--- a/bakta/features/nc_rna.py
+++ b/bakta/features/nc_rna.py
@@ -108,15 +108,7 @@ def predict_nc_rnas(genome: dict, contigs_path: Path):
                         gene = gene[0].lower() + gene[1:]
                         log.debug('fix gene: lowercase first char. new=%s, old=%s', gene, subject)
                     ncrna['gene'] = gene
-
-                    if(truncated is None):
-                        ncrna['product'] = description
-                    elif(truncated == bc.FEATURE_END_UNKNOWN):
-                        ncrna['product'] = f'(partial) {description}'
-                    elif(truncated == bc.FEATURE_END_5_PRIME):
-                        ncrna['product'] = f"(5' truncated) {description}"
-                    elif(truncated == bc.FEATURE_END_3_PRIME):
-                        ncrna['product'] = f"(3' truncated) {description}"
+                    ncrna['product'] = description
 
                     if(ncrna['class'] is not None):
                         db_xrefs.append(ncrna['class'].id)

--- a/bakta/features/nc_rna_region.py
+++ b/bakta/features/nc_rna_region.py
@@ -100,15 +100,7 @@ def predict_nc_rna_regions(genome: dict, contigs_path: Path):
                     ncrna_region['stop'] = stop
                     ncrna_region['strand'] = bc.STRAND_FORWARD if strand == '+' else bc.STRAND_REVERSE
                     ncrna_region['label'] = subject
-
-                    if(truncated is None):
-                        ncrna_region['product'] = description
-                    elif(truncated == bc.FEATURE_END_UNKNOWN):
-                        ncrna_region['product'] = f'(partial) {description}'
-                    elif(truncated == bc.FEATURE_END_5_PRIME):
-                        ncrna_region['product'] = f"(5' truncated) {description}"
-                    elif(truncated == bc.FEATURE_END_3_PRIME):
-                        ncrna_region['product'] = f"(3' truncated) {description}"
+                    ncrna_region['product'] = description
 
                     if(ncrna_region['class'] is not None):
                         db_xrefs.append(ncrna_region['class'].id)

--- a/bakta/features/r_rna.py
+++ b/bakta/features/r_rna.py
@@ -116,15 +116,7 @@ def predict_r_rnas(genome: dict, contigs_path: Path):
                         rrna['gene'] = 'rrs'
                     elif(accession == 'RF02541'):
                         rrna['gene'] = 'rrl'
-
-                    if(truncated is None):
-                        rrna['product'] = f'{rrna_tag} ribosomal RNA'
-                    elif(truncated == bc.FEATURE_END_UNKNOWN):
-                        rrna['product'] = f'(partial) {rrna_tag} ribosomal RNA'
-                    elif(truncated == bc.FEATURE_END_5_PRIME):
-                        rrna['product'] = f"(5' truncated) {rrna_tag} ribosomal RNA"
-                    elif(truncated == bc.FEATURE_END_3_PRIME):
-                        rrna['product'] = f"(3' truncated) {rrna_tag} ribosomal RNA"
+                    rrna['product'] = f'{rrna_tag} ribosomal RNA'
 
                     if(truncated):
                         rrna['truncated'] = truncated

--- a/bakta/features/t_rna.py
+++ b/bakta/features/t_rna.py
@@ -97,7 +97,7 @@ def predict_t_rnas(genome: dict, contigs_path: Path):
                 trna['anti_codon'] = anti_codon.lower()
 
             if('pseudo' in note):
-                trna['pseudo'] = True
+                trna[bc.PSEUDOGENE] = True
 
             trna['score'] = float(score)
 

--- a/bakta/io/gff.py
+++ b/bakta/io/gff.py
@@ -60,7 +60,9 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                     }
                     if(feat.get('gene', None)):  # add gene annotation if available
                         annotations['gene'] = feat['gene']
-                    if(feat.get('pseudo', False)):
+                    if(bc.PSEUDOGENE in feat):
+                        annotations[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNKNOWN
+                    elif('truncated' in feat):
                         annotations['pseudo'] = True
                     if(feat.get('anti_codon', False)):
                         annotations['anti_codon'] = feat['anti_codon']
@@ -77,8 +79,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         }
                         if(feat.get('gene', None)):
                             gene_annotations['gene'] = feat['gene']
-                        if(feat.get('pseudo', None)):
-                            annotations[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNKNOWN
+                        if(bc.PSEUDOGENE in feat):
                             gene_annotations[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNKNOWN
                         gene_annotations = encode_annotations(gene_annotations)
                         fh.write(f"{feat['contig']}\ttRNAscan-SE\tgene\t{start}\t{stop}\t.\t{feat['strand']}\t.\t{gene_annotations}\n")
@@ -94,6 +95,8 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         'tag_peptide': feat['tag_aa'],
                         'Dbxref': feat['db_xrefs']
                     }
+                    if('truncated' in feat):
+                        annotations['pseudo'] = True
                     if(cfg.compliant):
                         gene_id = f"{feat['locus']}_gene"
                         annotations['Parent'] = gene_id
@@ -104,6 +107,8 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                             'locus_tag': feat['locus'],
                             'gene': feat['gene']
                         }
+                        if('truncated' in feat):
+                            gene_annotations['pseudo'] = True
                         gene_annotations = encode_annotations(gene_annotations)
                         fh.write(f"{feat['contig']}\tAragorn\tgene\t{start}\t{stop}\t.\t{feat['strand']}\t.\t{gene_annotations}\n")
                     annotations = encode_annotations(annotations)
@@ -117,6 +122,8 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         'product': feat['product'],
                         'Dbxref': feat['db_xrefs']
                     }
+                    if('truncated' in feat):
+                        annotations['pseudo'] = True
                     if(cfg.compliant):
                         gene_id = f"{feat['locus']}_gene"
                         annotations['Parent'] = gene_id
@@ -128,6 +135,8 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                             'locus_tag': feat['locus'],
                             'gene': feat['gene']
                         }
+                        if('truncated' in feat):
+                            gene_annotations['pseudo'] = True
                         gene_annotations = encode_annotations(gene_annotations)
                         fh.write(f"{feat['contig']}\tInfernal\tgene\t{start}\t{stop}\t.\t{feat['strand']}\t.\t{gene_annotations}\n")
                     annotations = encode_annotations(annotations)
@@ -141,6 +150,8 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         'product': feat['product'],
                         'Dbxref': feat['db_xrefs']
                     }
+                    if('truncated' in feat):
+                        annotations['pseudo'] = True
                     if(cfg.compliant):
                         gene_id = f"{feat['locus']}_gene"
                         gene_annotations = {
@@ -148,6 +159,8 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                             'locus_tag': feat['locus'],
                             'gene': feat['gene']
                         }
+                        if('truncated' in feat):
+                            gene_annotations['pseudo'] = True
                         annotations['Parent'] = gene_id
                         for rfam_id in [dbxref.split(':')[1] for dbxref in feat['db_xrefs'] if dbxref.split(':')[0] == bc.DB_XREF_RFAM]:
                             annotations['inference'] = f'profile:Rfam:{rfam_id}'
@@ -164,6 +177,8 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         'product': feat['product'],
                         'Dbxref': feat['db_xrefs']
                     }
+                    if('truncated' in feat):
+                        annotations['pseudo'] = True
                     if(cfg.compliant):
                         for rfam_id in [dbxref.split(':')[1] for dbxref in feat['db_xrefs'] if dbxref.split(':')[0] == bc.DB_XREF_RFAM]:
                             annotations['inference'] = f'profile:Rfam:{rfam_id}'
@@ -221,7 +236,9 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         'product': feat['product'],
                         'Dbxref': feat['db_xrefs']
                     }
-                    if(feat.get('pseudo', False)):
+                    if(bc.PSEUDOGENE in feat):
+                        annotations[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNPROCESSED if feat[bc.PSEUDOGENE]['paralog'] else bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNITARY
+                    elif('truncated' in feat):
                         annotations['pseudo'] = True
                     if(feat.get('gene', None)):  # add gene annotation if available
                         annotations['gene'] = feat['gene']
@@ -241,8 +258,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                             annotations['inference'] = 'ab initio prediction:Prodigal:2.6'
                         annotations['Dbxref'], annotations['Note'] = insdc.revise_dbxref_insdc(feat['db_xrefs'])  # remove INSDC invalid DbXrefs
                         annotations['Note'], ec_number = insdc.extract_ec_from_notes_insdc(annotations, 'Note')
-                        if(feat.get('pseudo', False)):
-                            annotations[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNPROCESSED if feat[bc.PSEUDOGENE]['paralog'] else bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNITARY
+                        if(bc.PSEUDOGENE in feat):
                             gene_annotations[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNPROCESSED if feat[bc.PSEUDOGENE]['paralog'] else bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNITARY
                         if(ec_number is not None):
                             annotations['ec_number'] = ec_number

--- a/bakta/io/gff.py
+++ b/bakta/io/gff.py
@@ -63,7 +63,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                     if(bc.PSEUDOGENE in feat):
                         annotations[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNKNOWN
                     elif('truncated' in feat):
-                        annotations['pseudo'] = True
+                        annotations[bc.INSDC_FEATURE_PSEUDO] = True
                     if(feat.get('anti_codon', False)):
                         annotations['anti_codon'] = feat['anti_codon']
                     if(feat.get('amino_acid', False)):
@@ -96,7 +96,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         'Dbxref': feat['db_xrefs']
                     }
                     if('truncated' in feat):
-                        annotations['pseudo'] = True
+                        annotations[bc.INSDC_FEATURE_PSEUDO] = True
                     if(cfg.compliant):
                         gene_id = f"{feat['locus']}_gene"
                         annotations['Parent'] = gene_id
@@ -108,7 +108,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                             'gene': feat['gene']
                         }
                         if('truncated' in feat):
-                            gene_annotations['pseudo'] = True
+                            gene_annotations[bc.INSDC_FEATURE_PSEUDO] = True
                         gene_annotations = encode_annotations(gene_annotations)
                         fh.write(f"{feat['contig']}\tAragorn\tgene\t{start}\t{stop}\t.\t{feat['strand']}\t.\t{gene_annotations}\n")
                     annotations = encode_annotations(annotations)
@@ -123,7 +123,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         'Dbxref': feat['db_xrefs']
                     }
                     if('truncated' in feat):
-                        annotations['pseudo'] = True
+                        annotations[bc.INSDC_FEATURE_PSEUDO] = True
                     if(cfg.compliant):
                         gene_id = f"{feat['locus']}_gene"
                         annotations['Parent'] = gene_id
@@ -136,7 +136,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                             'gene': feat['gene']
                         }
                         if('truncated' in feat):
-                            gene_annotations['pseudo'] = True
+                            gene_annotations[bc.INSDC_FEATURE_PSEUDO] = True
                         gene_annotations = encode_annotations(gene_annotations)
                         fh.write(f"{feat['contig']}\tInfernal\tgene\t{start}\t{stop}\t.\t{feat['strand']}\t.\t{gene_annotations}\n")
                     annotations = encode_annotations(annotations)
@@ -151,7 +151,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         'Dbxref': feat['db_xrefs']
                     }
                     if('truncated' in feat):
-                        annotations['pseudo'] = True
+                        annotations[bc.INSDC_FEATURE_PSEUDO] = True
                     if(cfg.compliant):
                         gene_id = f"{feat['locus']}_gene"
                         gene_annotations = {
@@ -160,7 +160,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                             'gene': feat['gene']
                         }
                         if('truncated' in feat):
-                            gene_annotations['pseudo'] = True
+                            gene_annotations[bc.INSDC_FEATURE_PSEUDO] = True
                         annotations['Parent'] = gene_id
                         for rfam_id in [dbxref.split(':')[1] for dbxref in feat['db_xrefs'] if dbxref.split(':')[0] == bc.DB_XREF_RFAM]:
                             annotations['inference'] = f'profile:Rfam:{rfam_id}'
@@ -178,7 +178,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                         'Dbxref': feat['db_xrefs']
                     }
                     if('truncated' in feat):
-                        annotations['pseudo'] = True
+                        annotations[bc.INSDC_FEATURE_PSEUDO] = True
                     if(cfg.compliant):
                         for rfam_id in [dbxref.split(':')[1] for dbxref in feat['db_xrefs'] if dbxref.split(':')[0] == bc.DB_XREF_RFAM]:
                             annotations['inference'] = f'profile:Rfam:{rfam_id}'
@@ -239,7 +239,7 @@ def write_gff3(genome: dict, features_by_contig: Dict[str, dict], gff3_path: Pat
                     if(bc.PSEUDOGENE in feat):
                         annotations[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNPROCESSED if feat[bc.PSEUDOGENE]['paralog'] else bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNITARY
                     elif('truncated' in feat):
-                        annotations['pseudo'] = True
+                        annotations[bc.INSDC_FEATURE_PSEUDO] = True
                     if(feat.get('gene', None)):  # add gene annotation if available
                         annotations['gene'] = feat['gene']
                     source = '?' if feat.get('source', None) == bc.CDS_SOURCE_USER else 'Prodigal'

--- a/bakta/io/insdc.py
+++ b/bakta/io/insdc.py
@@ -235,7 +235,7 @@ def write_insdc(genome: dict, features: Sequence[dict], genbank_output_path: Pat
             else:
                 if('truncated' in feature):
                     if(bc.PSEUDOGENE not in feature):  # only add /pseudo qualifier if /pseudogene is not already set
-                        qualifiers['pseudo'] = None
+                        qualifiers[bc.INSDC_FEATURE_PSEUDO] = None
                     if(feature['truncated'] == bc.FEATURE_END_5_PRIME):
                         qualifiers['note'].append("(5' truncated)")
                         if(feature['strand'] == bc.STRAND_FORWARD):
@@ -266,7 +266,7 @@ def write_insdc(genome: dict, features: Sequence[dict], genbank_output_path: Pat
                     else:
                         gene_qualifier[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNKNOWN
                 elif('truncated' in feature):
-                    gene_qualifier['pseudo'] = None
+                    gene_qualifier[bc.INSDC_FEATURE_PSEUDO] = None
                 gen_seqfeat = SeqFeature(feature_location, type='gene', qualifiers=gene_qualifier)
                 seq_feature_list.append(gen_seqfeat)
             feat_seqfeat = SeqFeature(feature_location, type=insdc_feature_type, qualifiers=qualifiers)

--- a/bakta/io/insdc.py
+++ b/bakta/io/insdc.py
@@ -122,8 +122,9 @@ def write_insdc(genome: dict, features: Sequence[dict], genbank_output_path: Pat
                 if('product' in qualifiers):
                     del qualifiers['product']
             elif(feature['type'] == bc.FEATURE_CDS) or (feature['type'] == bc.FEATURE_SORF):
-                if(feature.get('pseudo', False)):
+                if(bc.PSEUDOGENE in feature):
                     qualifiers[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNPROCESSED if feature[bc.PSEUDOGENE]['paralog'] else bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNITARY
+                    qualifiers['note'].append(feature[bc.PSEUDOGENE]['description'])
                 else:
                     qualifiers['protein_id'] = f"gnl|Bakta|{feature['locus']}"
                     qualifiers['translation'] = feature['aa']
@@ -158,8 +159,6 @@ def write_insdc(genome: dict, features: Sequence[dict], genbank_output_path: Pat
                     qualifiers['note'], ec_number = extract_ec_from_notes_insdc(qualifiers, 'note')
                     if(ec_number is not None):
                             qualifiers['EC_number'] = ec_number
-                if(feature.get('pseudo', False)):
-                    qualifiers['note'].append(feature[bc.PSEUDOGENE]['description'])
                 if('exception' in feature):
                     ex = feature['exception']
                     pos = f"{ex['start']}..{ex['stop']}"
@@ -185,8 +184,8 @@ def write_insdc(genome: dict, features: Sequence[dict], genbank_output_path: Pat
                         qualifiers['note'] = f"tRNA-{feature['amino_acid']} ({feature['anti_codon']})"
                 qualifiers['inference'] = 'profile:tRNAscan:2.0'
                 insdc_feature_type = bc.INSDC_FEATURE_T_RNA
-                if('pseudo' in feature):
-                    qualifiers['pseudo'] = None
+                if(bc.PSEUDOGENE in feature):
+                    qualifiers[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNKNOWN
             elif(feature['type'] == bc.FEATURE_TM_RNA):
                 qualifiers['inference'] = 'profile:aragorn:1.2'
                 qualifiers['tag_peptide'] = feature['tag_aa']
@@ -235,17 +234,22 @@ def write_insdc(genome: dict, features: Sequence[dict], genbank_output_path: Pat
                     feature_location = CompoundLocation([fl_1, fl_2])
             else:
                 if('truncated' in feature):
+                    if(bc.PSEUDOGENE not in feature):  # only add /pseudo qualifier if /pseudogene is not already set
+                        qualifiers['pseudo'] = None
                     if(feature['truncated'] == bc.FEATURE_END_5_PRIME):
+                        qualifiers['note'].append("(5' truncated)")
                         if(feature['strand'] == bc.STRAND_FORWARD):
                             start = BeforePosition(start)
                         else:
                             stop = AfterPosition(stop)
                     elif(feature['truncated'] == bc.FEATURE_END_3_PRIME):
+                        qualifiers['note'].append("(3' truncated)")
                         if(feature['strand'] == bc.STRAND_FORWARD):
                             stop = AfterPosition(stop)
                         else:
                             start = BeforePosition(start)
                     elif(feature['truncated'] == bc.FEATURE_END_BOTH):
+                        qualifiers['note'].append('(partial)')
                         start = BeforePosition(start)
                         stop = AfterPosition(stop)
                 feature_location = FeatureLocation(start, stop, strand=strand)
@@ -256,8 +260,13 @@ def write_insdc(genome: dict, features: Sequence[dict], genbank_output_path: Pat
                 if(feature.get('gene', None)):
                     qualifiers['gene'] = feature['gene']
                     gene_qualifier['gene'] = feature['gene']
-                if(feature.get(bc.PSEUDOGENE, None)):
-                    gene_qualifier[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNPROCESSED if feature[bc.PSEUDOGENE]['paralog'] else bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNITARY
+                if(bc.PSEUDOGENE in feature):
+                    if(feature['type'] == bc.FEATURE_CDS):
+                        gene_qualifier[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNPROCESSED if feature[bc.PSEUDOGENE]['paralog'] else bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNITARY
+                    else:
+                        gene_qualifier[bc.INSDC_FEATURE_PSEUDOGENE] = bc.INSDC_FEATURE_PSEUDOGENE_TYPE_UNKNOWN
+                elif('truncated' in feature):
+                    gene_qualifier['pseudo'] = None
                 gen_seqfeat = SeqFeature(feature_location, type='gene', qualifiers=gene_qualifier)
                 seq_feature_list.append(gen_seqfeat)
             feat_seqfeat = SeqFeature(feature_location, type=insdc_feature_type, qualifiers=qualifiers)

--- a/bakta/io/tsv.py
+++ b/bakta/io/tsv.py
@@ -31,7 +31,16 @@ def write_tsv(contigs: Sequence[dict], features_by_contig: Dict[str, dict], tsv_
                     feat_type = bc.INSDC_FEATURE_ASSEMBLY_GAP if feat['length'] >= 100 else bc.INSDC_FEATURE_GAP
 
                 gene = feat['gene'] if feat.get('gene', None) else ''
-                product = f"(pseudo) {feat.get('product', '')}" if feat.get('pseudo', False) else feat.get('product', '')
+                if(bc.PSEUDOGENE in feat):
+                    product = f"(pseudo) {feat.get('product', '')}"
+                elif(feat.get('truncated', '') == bc.FEATURE_END_5_PRIME):
+                    product = f"(5' truncated) {feat.get('product', '')}"
+                elif(feat['truncated'] == bc.FEATURE_END_3_PRIME):
+                    product = f"(3' truncated) {feat.get('product', '')}"
+                elif(feat['truncated'] == bc.FEATURE_END_BOTH):
+                    product = f"(partial) {feat.get('product', '')}"
+                else:
+                    product = feat.get('product', '')
                 fh.write('\t'.join(
                     [
                         feat['contig'],

--- a/bakta/io/tsv.py
+++ b/bakta/io/tsv.py
@@ -35,9 +35,9 @@ def write_tsv(contigs: Sequence[dict], features_by_contig: Dict[str, dict], tsv_
                     product = f"(pseudo) {feat.get('product', '')}"
                 elif(feat.get('truncated', '') == bc.FEATURE_END_5_PRIME):
                     product = f"(5' truncated) {feat.get('product', '')}"
-                elif(feat['truncated'] == bc.FEATURE_END_3_PRIME):
+                elif(feat.get('truncated', '') == bc.FEATURE_END_3_PRIME):
                     product = f"(3' truncated) {feat.get('product', '')}"
-                elif(feat['truncated'] == bc.FEATURE_END_BOTH):
+                elif(feat.get('truncated', '') == bc.FEATURE_END_BOTH):
                     product = f"(partial) {feat.get('product', '')}"
                 else:
                     product = feat.get('product', '')

--- a/bakta/io/tsv.py
+++ b/bakta/io/tsv.py
@@ -31,16 +31,15 @@ def write_tsv(contigs: Sequence[dict], features_by_contig: Dict[str, dict], tsv_
                     feat_type = bc.INSDC_FEATURE_ASSEMBLY_GAP if feat['length'] >= 100 else bc.INSDC_FEATURE_GAP
 
                 gene = feat['gene'] if feat.get('gene', None) else ''
+                product = feat.get('product', '')
                 if(bc.PSEUDOGENE in feat):
-                    product = f"(pseudo) {feat.get('product', '')}"
+                    product = f"(pseudo) {product}"
                 elif(feat.get('truncated', '') == bc.FEATURE_END_5_PRIME):
-                    product = f"(5' truncated) {feat.get('product', '')}"
+                    product = f"(5' truncated) {product}"
                 elif(feat.get('truncated', '') == bc.FEATURE_END_3_PRIME):
-                    product = f"(3' truncated) {feat.get('product', '')}"
+                    product = f"(3' truncated) {product}"
                 elif(feat.get('truncated', '') == bc.FEATURE_END_BOTH):
-                    product = f"(partial) {feat.get('product', '')}"
-                else:
-                    product = feat.get('product', '')
+                    product = f"(partial) {product}"
                 fh.write('\t'.join(
                     [
                         feat['contig'],


### PR DESCRIPTION
Bakta and various standard output formats (Genbank, EMBL, GFF3) use slightly different terms and approaches how to declare truncated genes and pseudogenes.

In Bakta, a feature is declared as _truncated_ if there is information from a downstream analysis tool, _e.g._ Pyrodigal, Infernal, etc.

Besides these, Bakta accepts true _pseudogenes__ from tRNAscan-SE and from its own internal CDS workflow.

To strictly follow *INSDC* specs, for _Genbank_, _EMBL_ and _GFF3_ output files, Bakta now declares all _truncated_ features as `pseudo` reflecting technical issues like sequencing and assembly errors on the one side, and true `pseudogenes` on the other side emerging from biological pseudogenization events like InDels and mutations.

Internally, Bakta uses `truncated` and `pseudogene` attributes to reflect the different states. In the human readable `TSV` output file (meant for a quick glimpse), Bakta adds feature product prefixes `(pseudo)`,  `(truncated)`, `(5' truncated)` and (3' truncated)`.