### PR TITLE
updated environment.yml and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk update && apk add wget tar bash \
     && rm glibc-2.32-r0.apk \
     && wget --no-iri -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba \
     && touch /root/.bashrc \
-    && ./bin/micromamba shell init -s bash -p /opt/conda  \
+    && ./bin/micromamba shell init -s bash -r /opt/conda  \
     && cp /root/.bashrc /opt/conda/bashrc
 
 COPY environment.yml /tmp/

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python>=3.9,<3.12
+  - python >=3.9,<3.12
   - biopython>=1.78
   - xopen>=1.5.0
   - requests>=2.25.1

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python <3.12,>=3.9
+  - python>=3.9,<3.12
   - biopython>=1.78
   - xopen>=1.5.0
   - requests>=2.25.1

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - python <3.12,>=3.9
   - biopython>=1.78
   - xopen>=1.5.0
   - requests>=2.25.1


### PR DESCRIPTION
Hello! I needed a container with v1.10 and since the update was so fresh I just went ahead and built it. 

Just a few fixes in this PR that resolves #342 

**1. Micromamba's [syntax changed](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html) and I updated the Dockerfile to reflect this.** 

```
[+] Building 25.6s (6/10)                                                                                                                                                                                                      docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.1s
 => => transferring dockerfile: 2.29kB                                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                                                                                                                                                                           1.1s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
 => => transferring context: 112B                                                                                                                                                                                                        0.0s
 => [1/6] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69                                                                                                                     2.3s
 => => resolve docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69                                                                                                                     0.0s
 => => sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69 1.64kB / 1.64kB                                                                                                                                           0.0s
 => => sha256:cb64bbe7fa613666c234e1090e91427314ee18ec6420e9426cf4e7f314056813 528B / 528B                                                                                                                                               0.0s
 => => sha256:24c8ece58a1aa807c0d8ea121f91cee2efba99624d0a8aed732155fb31f28993 1.47kB / 1.47kB                                                                                                                                           0.0s
 => => sha256:1b7ca6aea1ddfe716f3694edb811ab35114db9e93f3ce38d7dab6b4d9270cb0c 2.81MB / 2.81MB                                                                                                                                           2.1s
 => => extracting sha256:1b7ca6aea1ddfe716f3694edb811ab35114db9e93f3ce38d7dab6b4d9270cb0c                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                        0.4s
 => => transferring context: 137.68MB                                                                                                                                                                                                    0.3s
 => ERROR [2/6] RUN apk update && apk add wget tar bash     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub     && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/  22.1s
------
 > [2/6] RUN apk update && apk add wget tar bash     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub     && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk     && apk add glibc-2.32-r0.apk     && rm glibc-2.32-r0.apk     && wget --no-iri -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba     && touch /root/.bashrc     && ./bin/micromamba shell init -s bash -p /opt/conda      && cp /root/.bashrc /opt/conda/bashrc:
0.255 fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
12.50 fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
13.23 v3.12.12-53-gc96f3238172 [http://dl-cdn.alpinelinux.org/alpine/v3.12/main]
13.23 v3.12.12-52-g800c17231ad [http://dl-cdn.alpinelinux.org/alpine/v3.12/community]
13.23 OK: 12767 distinct packages available
13.33 (1/9) Installing ncurses-terminfo-base (6.2_p20200523-r1)
13.55 (2/9) Installing ncurses-libs (6.2_p20200523-r1)
13.85 (3/9) Installing readline (8.0.4-r0)
14.02 (4/9) Installing bash (5.0.17-r0)
14.31 Executing bash-5.0.17-r0.post-install
14.31 (5/9) Installing libacl (2.2.53-r0)
14.40 (6/9) Installing tar (1.32-r2)
14.58 (7/9) Installing libunistring (0.9.10-r0)
14.86 (8/9) Installing libidn2 (2.3.0-r0)
14.95 (9/9) Installing wget (1.20.3-r1)
15.10 Executing busybox-1.31.1-r22.trigger
15.10 OK: 10 MiB in 23 packages
15.74 --2024-11-14 22:09:56--  https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk
15.75 Resolving github.com (github.com)... 140.82.112.4
15.75 Connecting to github.com (github.com)|140.82.112.4|:443... connected.
15.85 HTTP request sent, awaiting response... 302 Found
16.00 Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/33333969/d4cfa880-d89f-11ea-9b3d-e2a2cba4ad38?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241114%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241114T220956Z&X-Amz-Expires=300&X-Amz-Signature=58bf1a4d1cb087938b23d0822e3fcb4a077f9b0211bd247dadfa37a616626365&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dglibc-2.32-r0.apk&response-content-type=application%2Fvnd.android.package-archive [following]
16.00 --2024-11-14 22:09:56--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/33333969/d4cfa880-d89f-11ea-9b3d-e2a2cba4ad38?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20241114%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241114T220956Z&X-Amz-Expires=300&X-Amz-Signature=58bf1a4d1cb087938b23d0822e3fcb4a077f9b0211bd247dadfa37a616626365&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dglibc-2.32-r0.apk&response-content-type=application%2Fvnd.android.package-archive
16.00 Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.109.133, 185.199.108.133, 185.199.111.133, ...
16.02 Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.109.133|:443... connected.
16.11 HTTP request sent, awaiting response... 200 OK
16.24 Length: 4435333 (4.2M) [application/vnd.android.package-archive]
16.24 Saving to: 'glibc-2.32-r0.apk'
16.24
16.24      0K .......... .......... .......... .......... ..........  1%  885K 5s
16.29     50K .......... .......... .......... .......... ..........  2% 1.30M 4s
16.33    100K .......... .......... .......... .......... ..........  3% 4.32M 3s
16.34    150K .......... .......... .......... .......... ..........  4% 5.63M 2s
16.35    200K .......... .......... .......... .......... ..........  5% 2.08M 2s
16.37    250K .......... .......... .......... .......... ..........  6% 7.34M 2s
16.38    300K .......... .......... .......... .......... ..........  8% 8.54M 2s
16.39    350K .......... .......... .......... .......... ..........  9% 9.55M 2s
16.39    400K .......... .......... .......... .......... .......... 10% 7.85M 1s
16.40    450K .......... .......... .......... .......... .......... 11% 2.58M 1s
16.42    500K .......... .......... .......... .......... .......... 12% 14.0M 1s
16.42    550K .......... .......... .......... .......... .......... 13% 15.9M 1s
16.42    600K .......... .......... .......... .......... .......... 15% 14.5M 1s
16.43    650K .......... .......... .......... .......... .......... 16% 16.2M 1s
16.43    700K .......... .......... .......... .......... .......... 17% 17.8M 1s
16.43    750K .......... .......... .......... .......... .......... 18% 18.7M 1s
16.44    800K .......... .......... .......... .......... .......... 19% 15.0M 1s
16.44    850K .......... .......... .......... .......... .......... 20% 22.1M 1s
16.44    900K .......... .......... .......... .......... .......... 21% 24.0M 1s
16.44    950K .......... .......... .......... .......... .......... 23% 25.5M 1s
16.45   1000K .......... .......... .......... .......... .......... 24% 3.01M 1s
16.46   1050K .......... .......... .......... .......... .......... 25% 18.2M 1s
16.46   1100K .......... .......... .......... .......... .......... 26% 31.8M 1s
16.47   1150K .......... .......... .......... .......... .......... 27% 31.2M 1s
16.47   1200K .......... .......... .......... .......... .......... 28% 21.6M 1s
16.47   1250K .......... .......... .......... .......... .......... 30% 28.3M 1s
16.47   1300K .......... .......... .......... .......... .......... 31% 24.7M 1s
16.47   1350K .......... .......... .......... .......... .......... 32% 75.9M 0s
16.47   1400K .......... .......... .......... .......... .......... 33% 23.8M 0s
16.48   1450K .......... .......... .......... .......... .......... 34% 45.2M 0s
16.48   1500K .......... .......... .......... .......... .......... 35% 35.8M 0s
16.48   1550K .......... .......... .......... .......... .......... 36% 49.2M 0s
16.48   1600K .......... .......... .......... .......... .......... 38% 25.0M 0s
16.48   1650K .......... .......... .......... .......... .......... 39% 33.7M 0s
16.48   1700K .......... .......... .......... .......... .......... 40% 63.0M 0s
16.48   1750K .......... .......... .......... .......... .......... 41% 37.0M 0s
16.48   1800K .......... .......... .......... .......... .......... 42% 46.8M 0s
16.49   1850K .......... .......... .......... .......... .......... 43% 44.0M 0s
16.49   1900K .......... .......... .......... .......... .......... 45% 51.4M 0s
16.49   1950K .......... .......... .......... .......... .......... 46% 36.8M 0s
16.49   2000K .......... .......... .......... .......... .......... 47% 38.8M 0s
16.49   2050K .......... .......... .......... .......... .......... 48% 3.14M 0s
16.51   2100K .......... .......... .......... .......... .......... 49% 62.3M 0s
16.51   2150K .......... .......... .......... .......... .......... 50% 27.4M 0s
16.51   2200K .......... .......... .......... .......... .......... 51% 72.8M 0s
16.51   2250K .......... .......... .......... .......... .......... 53%  161M 0s
16.51   2300K .......... .......... .......... .......... .......... 54% 31.7M 0s
16.51   2350K .......... .......... .......... .......... .......... 55% 50.0M 0s
16.51   2400K .......... .......... .......... .......... .......... 56% 47.7M 0s
16.51   2450K .......... .......... .......... .......... .......... 57% 78.2M 0s
16.51   2500K .......... .......... .......... .......... .......... 58%  108M 0s
16.51   2550K .......... .......... .......... .......... .......... 60% 29.7M 0s
16.52   2600K .......... .......... .......... .......... .......... 61%  126M 0s
16.52   2650K .......... .......... .......... .......... .......... 62% 62.3M 0s
16.52   2700K .......... .......... .......... .......... .......... 63% 61.5M 0s
16.52   2750K .......... .......... .......... .......... .......... 64%  126M 0s
16.52   2800K .......... .......... .......... .......... .......... 65% 37.1M 0s
16.52   2850K .......... .......... .......... .......... .......... 66% 68.9M 0s
16.52   2900K .......... .......... .......... .......... .......... 68% 38.9M 0s
16.52   2950K .......... .......... .......... .......... .......... 69%  323M 0s
16.52   3000K .......... .......... .......... .......... .......... 70%  101M 0s
16.52   3050K .......... .......... .......... .......... .......... 71% 67.1M 0s
16.52   3100K .......... .......... .......... .......... .......... 72% 66.4M 0s
16.52   3150K .......... .......... .......... .......... .......... 73%  195M 0s
16.52   3200K .......... .......... .......... .......... .......... 75% 51.9M 0s
16.52   3250K .......... .......... .......... .......... .......... 76% 57.5M 0s
16.53   3300K .......... .......... .......... .......... .......... 77% 70.1M 0s
16.53   3350K .......... .......... .......... .......... .......... 78% 56.3M 0s
16.53   3400K .......... .......... .......... .......... .......... 79%  469M 0s
16.53   3450K .......... .......... .......... .......... .......... 80% 71.5M 0s
16.53   3500K .......... .......... .......... .......... .......... 81% 74.6M 0s
16.53   3550K .......... .......... .......... .......... .......... 83% 69.9M 0s
16.53   3600K .......... .......... .......... .......... .......... 84% 59.9M 0s
16.53   3650K .......... .......... .......... .......... .......... 85% 70.9M 0s
16.53   3700K .......... .......... .......... .......... .......... 86%  324M 0s
16.53   3750K .......... .......... .......... .......... .......... 87% 67.1M 0s
16.53   3800K .......... .......... .......... .......... .......... 88% 87.9M 0s
16.53   3850K .......... .......... .......... .......... .......... 90% 66.6M 0s
16.53   3900K .......... .......... .......... .......... .......... 91%  301M 0s
16.53   3950K .......... .......... .......... .......... .......... 92% 68.2M 0s
16.53   4000K .......... .......... .......... .......... .......... 93% 75.2M 0s
16.53   4050K .......... .......... .......... .......... .......... 94% 71.9M 0s
16.54   4100K .......... .......... .......... .......... .......... 95% 3.24M 0s
16.55   4150K .......... .......... .......... .......... .......... 96%  503M 0s
16.55   4200K .......... .......... .......... .......... .......... 98%  120M 0s
16.55   4250K .......... .......... .......... .......... .......... 99% 78.3M 0s
16.55   4300K .......... .......... .......... .                    100%  542M=0.3s
16.55
16.55 2024-11-14 22:09:57 (13.5 MB/s) - 'glibc-2.32-r0.apk' saved [4435333/4435333]
16.55
16.70 (1/1) Installing glibc (2.32-r0)
16.76 OK: 19 MiB in 24 packages
18.73 bin/micromamba
21.99 The following argument was not expected: -p
21.99 Run with --help for more information.
------
Dockerfile:9
--------------------
   8 |
   9 | >>> RUN apk update && apk add wget tar bash \
  10 | >>>     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
  11 | >>>     && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk \
  12 | >>>     && apk add glibc-2.32-r0.apk \
  13 | >>>     && rm glibc-2.32-r0.apk \
  14 | >>>     && wget --no-iri -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba \
  15 | >>>     && touch /root/.bashrc \
  16 | >>>     && ./bin/micromamba shell init -s bash -p /opt/conda  \
  17 | >>>     && cp /root/.bashrc /opt/conda/bashrc
  18 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apk update && apk add wget tar bash     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub     && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk     && apk add glibc-2.32-r0.apk     && rm glibc-2.32-r0.apk     && wget --no-iri -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba     && touch /root/.bashrc     && ./bin/micromamba shell init -s bash -p /opt/conda      && cp /root/.bashrc /opt/conda/bashrc" did not complete successfully: exit code: 109
```

***

**2. Specifying the python version in environment.yml was also required to build successfully.**

```[+] Building 52.7s (10/10) FINISHED                                                                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 2.29kB                                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/alpine:3.12                                                                                                                                                                           0.3s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
 => => transferring context: 112B                                                                                                                                                                                                        0.0s
 => CACHED [1/6] FROM docker.io/library/alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69                                                                                                              0.0s
 => [internal] load build context                                                                                                                                                                                                        0.0s
 => => transferring context: 14.22kB                                                                                                                                                                                                     0.0s
 => [2/6] RUN apk update && apk add wget tar bash     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub     && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r  10.5s
 => [3/6] COPY environment.yml /tmp/                                                                                                                                                                                                     0.1s
 => [4/6] RUN source /opt/conda/bashrc && micromamba activate     && micromamba install -y -n base -f /tmp/environment.yml     && micromamba clean --all --yes                                                                          40.4s
 => [5/6] COPY . /tmp/source/                                                                                                                                                                                                            0.3s
 => ERROR [6/6] RUN source /opt/conda/bashrc && micromamba activate     && python3 -m pip install --no-cache /tmp/source/     && echo '#!/bin/bash' > /entrypoint.sh     && echo 'bakta "$@"' >> /entrypoint.sh     && chmod +x /entryp  1.1s
------
 > [6/6] RUN source /opt/conda/bashrc && micromamba activate     && python3 -m pip install --no-cache /tmp/source/     && echo '#!/bin/bash' > /entrypoint.sh     && echo 'bakta "$@"' >> /entrypoint.sh     && chmod +x /entrypoint.sh         && mv /bin/bash /bin/bash.orig     && echo '#!/bin/bash.orig' >> /bin/bash     && echo 'if [[ -z $MAMBA_INITIALIZED ]]' >> /bin/bash     && echo 'then' >> /bin/bash     && echo 'source /opt/conda/bashrc' >> /bin/bash     && echo 'micromamba activate' >> /bin/bash     && echo 'export MAMBA_INITIALIZED=1' >> /bin/bash     && echo 'fi' >> /bin/bash     && echo '/bin/bash.orig "$@"' >> /bin/bash     && chmod +x /bin/bash:
0.573 Processing /tmp/source
0.574   Preparing metadata (setup.py): started
0.723   Preparing metadata (setup.py): finished with status 'done'
0.727 Requirement already satisfied: biopython>=1.78 in /opt/conda/lib/python3.12/site-packages (from bakta==1.10.0) (1.84)
0.728 Requirement already satisfied: xopen>=1.5.0 in /opt/conda/lib/python3.12/site-packages (from bakta==1.10.0) (2.0.2)
0.728 Requirement already satisfied: requests>=2.25.1 in /opt/conda/lib/python3.12/site-packages (from bakta==1.10.0) (2.32.3)
0.728 Requirement already satisfied: alive-progress>=3.0.1 in /opt/conda/lib/python3.12/site-packages (from bakta==1.10.0) (3.1.5)
0.729 Requirement already satisfied: PyYAML>=6.0 in /opt/conda/lib/python3.12/site-packages (from bakta==1.10.0) (6.0.2)
0.729 Requirement already satisfied: pyrodigal>=3.5.0 in /opt/conda/lib/python3.12/site-packages (from bakta==1.10.0) (3.6.3)
0.729 Requirement already satisfied: pyhmmer>=0.10.15 in /opt/conda/lib/python3.12/site-packages (from bakta==1.10.0) (0.10.15)
0.730 Requirement already satisfied: pycirclize>=1.7.0 in /opt/conda/lib/python3.12/site-packages (from bakta==1.10.0) (1.7.1)
0.730 INFO: pip is looking at multiple versions of bakta to determine which version is compatible with other requirements. This could take a while.
1.002 ERROR: Package 'bakta' requires a different Python: 3.12.7 not in '<3.12,>=3.9'
------
Dockerfile:29
--------------------
  28 |
  29 | >>> RUN source /opt/conda/bashrc && micromamba activate \
  30 | >>>     && python3 -m pip install --no-cache /tmp/source/ \
  31 | >>>     && echo '#!/bin/bash' > /entrypoint.sh \
  32 | >>>     && echo 'bakta "$@"' >> /entrypoint.sh \
  33 | >>>     && chmod +x /entrypoint.sh \
  34 | >>>     \
  35 | >>>     # replace bash with a wrapper that initializes the micromamba env
  36 | >>>     # everytime it is not initialized.
  37 | >>>     # with this approach we can initialize the env automatically, even
  38 | >>>     # in non-interactive, no-login sessions, e.g. when nextflow uses
  39 | >>>     # containers
  40 | >>>     && mv /bin/bash /bin/bash.orig \
  41 | >>>     && echo '#!/bin/bash.orig' >> /bin/bash \
  42 | >>>     && echo 'if [[ -z $MAMBA_INITIALIZED ]]' >> /bin/bash \
  43 | >>>     && echo 'then' >> /bin/bash \
  44 | >>>     && echo 'source /opt/conda/bashrc' >> /bin/bash \
  45 | >>>     && echo 'micromamba activate' >> /bin/bash \
  46 | >>>     && echo 'export MAMBA_INITIALIZED=1' >> /bin/bash \
  47 | >>>     && echo 'fi' >> /bin/bash \
  48 | >>>     && echo '/bin/bash.orig "$@"' >> /bin/bash \
  49 | >>>     && chmod +x /bin/bash
  50 |
--------------------
ERROR: failed to solve: process "bash -l -c source /opt/conda/bashrc && micromamba activate     && python3 -m pip install --no-cache /tmp/source/     && echo '#!/bin/bash' > /entrypoint.sh     && echo 'bakta \"$@\"' >> /entrypoint.sh     && chmod +x /entrypoint.sh         && mv /bin/bash /bin/bash.orig     && echo '#!/bin/bash.orig' >> /bin/bash     && echo 'if [[ -z $MAMBA_INITIALIZED ]]' >> /bin/bash     && echo 'then' >> /bin/bash     && echo 'source /opt/conda/bashrc' >> /bin/bash     && echo 'micromamba activate' >> /bin/bash     && echo 'export MAMBA_INITIALIZED=1' >> /bin/bash     && echo 'fi' >> /bin/bash     && echo '/bin/bash.orig \"$@\"' >> /bin/bash     && chmod +x /bin/bash" did not complete successfully: exit code: 1
```