### PR TITLE
Fix: implement bakta_io backward compatibility

### DIFF
--- a/bakta/io/fasta.py
+++ b/bakta/io/fasta.py
@@ -72,7 +72,7 @@ def export_sequences(sequences: Sequence[dict], fasta_path: Path, description: b
             if(wrap):
                 fh.write(wrap_sequence(seq['nt'] if 'nt' in seq else seq['sequence']))  # <1.10.0 compatibility
             else:
-                fh.write(seq['nt'])
+                fh.write(seq['nt'] if 'nt' in seq else seq['sequence'])
                 fh.write('\n')
 
 


### PR DESCRIPTION
Fixes error when writing fna output and wrap=False

same logic as https://github.com/oschwengers/bakta/blob/bf2bb48fbcb12e70e83010db75011ed30323757c/bakta/io/fasta.py#L73