### PR TITLE
support partial genes on linear contigs #390

### DIFF
--- a/bakta.cwl
+++ b/bakta.cwl
@@ -127,6 +127,10 @@ inputs:
     id: meta
     inputBinding: {prefix: --meta}
     type: boolean?
+  - doc: Predict partial genes overlapping contig ends
+    id: partial
+    inputBinding: {prefix: --partials}
+    type: boolean?
   - doc: Skip tRNA detection & annotation
     id: skip_tRNA
     inputBinding: {prefix: --skip-trna}

--- a/bakta/config.py
+++ b/bakta/config.py
@@ -58,6 +58,7 @@ compliant = None
 user_proteins = None
 user_hmms = None
 meta = None
+partials = None
 regions = None
 
 # workflow configuration
@@ -165,7 +166,7 @@ def setup(args):
         taxon = None
 
     # annotation configurations
-    global complete, prodigal_tf, translation_table, keep_sequence_headers, locus, locus_tag, locus_tag_increment, gram, replicons, compliant, user_proteins, user_hmms, meta, regions
+    global complete, prodigal_tf, translation_table, keep_sequence_headers, locus, locus_tag, locus_tag_increment, gram, replicons, compliant, user_proteins, user_hmms, meta, partials, regions
     complete = args.complete
     log.info('complete=%s', complete)
     prodigal_tf = args.prodigal_tf
@@ -192,6 +193,8 @@ def setup(args):
         log.info('compliant mode! min_contig_length=%s', min_sequence_length)
     meta = args.meta
     log.info('meta=%s', meta)
+    partials = args.partials
+    log.info('partials=%s', partials)
     locus = args.locus
     if(locus is not None):
         if(locus == ''):

--- a/bakta/features/cds.py
+++ b/bakta/features/cds.py
@@ -29,7 +29,6 @@ from bakta.psc import DB_PSC_COL_UNIREF90
 
 log = logging.getLogger('CDS')
 
-
 def predict(data: dict):
     """Predict open reading frames with Pyrodigal."""
     # create Pyrodigal trainining file if not provided by the user
@@ -60,10 +59,11 @@ def predict(data: dict):
     # predict genes on linear sequences
     linear_sequences = [seq for seq in data['sequences'] if seq['topology'] == bc.TOPOLOGY_LINEAR]
     if(len(linear_sequences) > 0):
+        prodigal_closed = not cfg.partials  # allow partial genes at contig ends at user's request
         if prodigal_metamode:
-            gene_finder = pyrodigal.GeneFinder(meta=True, metagenomic_bins=None, closed=True, mask=True)
+            gene_finder = pyrodigal.GeneFinder(meta=True, metagenomic_bins=None, closed=prodigal_closed, mask=True)
         else:
-            gene_finder = pyrodigal.GeneFinder(trainings_info, meta=False, closed=True, mask=True)
+            gene_finder = pyrodigal.GeneFinder(trainings_info, meta=False, closed=prodigal_closed, mask=True)
         sequences = [seq['nt'] for seq in linear_sequences]
         with cf.ThreadPoolExecutor(max_workers=cfg.threads) as tpe:
             for seq, genes in zip(linear_sequences, tpe.map(gene_finder.find_genes, sequences)):

--- a/bakta/main.py
+++ b/bakta/main.py
@@ -74,6 +74,7 @@ def main():
         if(cfg.locus): print(f'\tlocus prefix: {cfg.locus}')
         if(cfg.locus_tag): print(f'\tlocus tag prefix: {cfg.locus_tag}')
         if(cfg.meta): print(f'\tmeta mode: {cfg.meta}')
+        if(cfg.partials): print(f'\tpredict partial genes: {cfg.partials}')
         if(cfg.complete): print(f'\tcomplete replicons: {cfg.complete}')
         print(f'\toutput: {cfg.output_path}')
         if(cfg.force): print(f'\tforce: {cfg.force}')

--- a/bakta/utils.py
+++ b/bakta/utils.py
@@ -93,6 +93,7 @@ def parse_arguments():
     arg_group_annotation.add_argument('--proteins', action='store', default=None, dest='proteins', help='Fasta file of trusted protein sequences for CDS annotation')
     arg_group_annotation.add_argument('--hmms', action='store', default=None, dest='hmms', help='HMM file of trusted hidden markov models in HMMER format for CDS annotation')
     arg_group_annotation.add_argument('--meta', action='store_true', help='Run in metagenome mode. This only affects CDS prediction.')
+    arg_group_annotation.add_argument('--partials', action='store_true', help='Predict partial (truncated) genes overlapping contig ends for linear sequences (already enabled for circular sequences)')
 
     arg_group_workflow = parser.add_argument_group('Workflow')
     arg_group_workflow.add_argument('--skip-trna', action='store_true', dest='skip_trna', help='Skip tRNA detection & annotation')


### PR DESCRIPTION
Added a command line option --partials to enable users to run pyrodigal in open CDS prediction mode. This reveals the presence of additional gene fragments in low contiguity draft genomes.

This is a proposed fix to #390. 

