### PR TITLE
reduce time complexity to get seq->features in build_biopython_sequen…

### DIFF
--- a/bakta/io/insdc.py
+++ b/bakta/io/insdc.py
@@ -1,6 +1,7 @@
 import logging
 import re
 
+from collections import defaultdict
 from datetime import date
 from pathlib import Path
 from typing import Sequence, Tuple


### PR DESCRIPTION
Fix #397

Use defaultdict to create required mapping of sequence to features and improve time complexity. This solution is much faster as it only has to process list of features once.

I have run tests on ubuntu VM and all have passed. I also compared the result of previous and suggested solution on ERR4333936 file and the embl/gbff output is the same. For ERR4333936 the build_biopython_sequence_list function takes 10seconds on my PC and instead of 20min. 

