### PR TITLE
Make AMRFinderPlus failure non-fatal

### DIFF
--- a/bakta/expert/amrfinder.py
+++ b/bakta/expert/amrfinder.py
@@ -44,7 +44,8 @@ def search(cdss: Sequence[dict], cds_fasta_path: Path):
     if(proc.returncode != 0):
         log.debug('stdout=\'%s\', stderr=\'%s\'', proc.stdout, proc.stderr)
         log.warning('AMR expert system failed! amrfinder-error-code=%d', proc.returncode)
-        raise Exception(f"amrfinder error! error code: {proc.returncode}. Please, try 'amrfinder_update --force_update --database {amrfinderplus_db_path}' to update AMRFinderPlus's internal database.")
+        log.warning("Continuing without AMR annotations. Try 'amrfinder_update --force_update --database %s' to update AMRFinderPlus's internal database.", amrfinderplus_db_path)
+        return set()
 
     cds_found = set()
     cds_by_hexdigest = orf.get_orf_dictionary(cdss)


### PR DESCRIPTION
## Summary

- AMRFinderPlus crashes are treated as warnings instead of fatal exceptions, allowing the rest of the annotation pipeline to complete
- Returns an empty result set on failure so downstream code (print count, output files) works unchanged
- Warning message preserved so users are still informed and can take corrective action

## Context

AMRFinderPlus can crash on certain inputs:
- Proteins with long runs of identical amino acids (https://github.com/ncbi/amr/issues/180, fixed in v4.2.7 but other triggers remain)
- BLAST database/threading issues (https://github.com/ncbi/amr/issues/145)

This causes the entire Bakta annotation to abort even when all other steps (CDS prediction, DIAMOND, Pfam, pseudogenes, etc.) would succeed. This is particularly painful for large metagenome assemblies where Bakta may run for hours before reaching the AMRFinder step.

Users have requested a `--skip-amr` flag (#268), and this issue has been reported multiple times (#416). Since the upstream AMRFinder bugs are outside Bakta's control, the pragmatic fix is to make the failure non-fatal.

## Changes

`bakta/expert/amrfinder.py` line 47: Replace `raise Exception(...)` with `log.warning(...)` + `return set()`

## Test plan

- [x] Verified on metagenome assembly (183K contigs, 1.5M CDS) where AMRFinderPlus crashes at `amr_report` stage
- [x] Bakta continues through DIAMOND, Pfam, pseudogene detection, and produces complete output (minus AMR annotations)
- [x] Warning message appears in log so users know AMR annotations are missing

Fixes #268
Relates to #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)