### PR TITLE
Add AMRFinder DB version logging and --amrfinder-db argument

### DIFF
--- a/bakta/config.py
+++ b/bakta/config.py
@@ -30,6 +30,8 @@ debug = None
 version = bakta.__version__
 db_path = None
 db_info = None
+amrfinderplus_db_path = None
+amrfinderplus_db_version = None
 tmp_path = None
 genome_path = None
 min_sequence_length = None
@@ -96,7 +98,9 @@ def setup(args):
 
     # input / output path configurations
     global db_path, db_info, tmp_path, genome_path, min_sequence_length, prefix, output_path, force
+    global amrfinderplus_db_path, amrfinderplus_db_version
     db_path = check_db_path(args)
+    check_amrfinderplus_db(args)
     tmp_path = check_tmp_path(args)
 
     try:
@@ -422,6 +426,24 @@ def check_user_proteins(args: Namespace):
             sys.exit(f'ERROR: user proteins file ({user_proteins}) not valid!')
     else:
         return None
+
+
+def check_amrfinderplus_db(args: Namespace):
+    global amrfinderplus_db_path, amrfinderplus_db_version
+    amrfinderplus_db_name = getattr(args, 'amrfinder_db', 'latest')
+    amrfinderplus_db_base = db_path.joinpath('amrfinderplus-db')
+    amrfinderplus_db_path = amrfinderplus_db_base.joinpath(amrfinderplus_db_name)
+    if not amrfinderplus_db_path.exists():
+        log.error('AMRFinderPlus database version not found: path=%s', amrfinderplus_db_path)
+        sys.exit(f"ERROR: AMRFinderPlus database version '{amrfinderplus_db_name}' not found! Valid options are folder names in: {amrfinderplus_db_base}")
+    # Resolve symlinks to determine actual version
+    amrfinderplus_db_resolved = amrfinderplus_db_path.resolve()
+    version_txt = amrfinderplus_db_resolved.joinpath('version.txt')
+    if version_txt.is_file():
+        amrfinderplus_db_version = version_txt.read_text().strip()
+    else:
+        amrfinderplus_db_version = amrfinderplus_db_resolved.name
+    log.info('amrfinderplus-db: path=%s, version=%s', amrfinderplus_db_path, amrfinderplus_db_version)
 
 
 def check_tmp_path(args: Namespace) -> Path:

--- a/bakta/expert/amrfinder.py
+++ b/bakta/expert/amrfinder.py
@@ -15,8 +15,6 @@ log = logging.getLogger('EXPERT-AMRFINDER')
 def search(cdss: Sequence[dict], cds_fasta_path: Path):
     """Conduct expert CDS analysis with AMRFinderPlus."""
     amrfinder_output_path = cfg.tmp_path.joinpath('amrfinder.tsv')
-    amrfinderplus_db_path = cfg.db_path.joinpath('amrfinderplus-db')
-    amrfinderplus_db_latest_path = amrfinderplus_db_path.joinpath('latest')
 
     amrfinderplus_tmp_path = cfg.tmp_path.joinpath('amrfinderplus')
     amrfinderplus_tmp_path.mkdir()
@@ -25,7 +23,7 @@ def search(cdss: Sequence[dict], cds_fasta_path: Path):
 
     cmd = [
         'amrfinder',
-        '--database', str(amrfinderplus_db_latest_path),
+        '--database', str(cfg.amrfinderplus_db_path),
         '--protein', str(cds_fasta_path),
         '--plus',
         '--translation_table', str(cfg.translation_table),
@@ -44,7 +42,7 @@ def search(cdss: Sequence[dict], cds_fasta_path: Path):
     if(proc.returncode != 0):
         log.debug('stdout=\'%s\', stderr=\'%s\'', proc.stdout, proc.stderr)
         log.warning('AMR expert system failed! amrfinder-error-code=%d', proc.returncode)
-        raise Exception(f"amrfinder error! error code: {proc.returncode}. Please, try 'amrfinder_update --force_update --database {amrfinderplus_db_path}' to update AMRFinderPlus's internal database.")
+        raise Exception(f"amrfinder error! error code: {proc.returncode}. Please, try 'amrfinder_update --force_update --database {cfg.db_path.joinpath('amrfinderplus-db')}' to update AMRFinderPlus's internal database.")
 
     cds_found = set()
     cds_by_hexdigest = orf.get_orf_dictionary(cdss)

--- a/bakta/io/gff.py
+++ b/bakta/io/gff.py
@@ -29,8 +29,7 @@ def write_features(data: dict, features_by_sequence: Dict[str, dict], gff3_path:
         fh.write('# Annotated with Bakta\n')
         fh.write(f'# Software: v{cfg.version}\n')
         fh.write(f"# Database: v{cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}\n")
-        if cfg.amrfinderplus_db_version:
-            fh.write(f'# AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
+        fh.write(f'# AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
         fh.write(f'# DOI: {bc.BAKTA_DOI}\n')
         fh.write(f'# URL: {bc.BAKTA_URL}\n')
 

--- a/bakta/io/gff.py
+++ b/bakta/io/gff.py
@@ -29,6 +29,8 @@ def write_features(data: dict, features_by_sequence: Dict[str, dict], gff3_path:
         fh.write('# Annotated with Bakta\n')
         fh.write(f'# Software: v{cfg.version}\n')
         fh.write(f"# Database: v{cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}\n")
+        if cfg.amrfinderplus_db_version:
+            fh.write(f'# AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
         fh.write(f'# DOI: {bc.BAKTA_DOI}\n')
         fh.write(f'# URL: {bc.BAKTA_URL}\n')
 

--- a/bakta/io/json.py
+++ b/bakta/io/json.py
@@ -37,7 +37,7 @@ def write_json(data: dict, features: Sequence[dict], json_path: Path):
         'version': f"{cfg.db_info['major']}.{cfg.db_info['minor']}",
         'type': cfg.db_info['type']
     }
-    version['amrfinderplus_db'] = cfg.amrfinderplus_db_version if cfg.amrfinderplus_db_version else None
+    version['amrfinderplus_db'] = cfg.amrfinderplus_db_version
     data['version'] = version
 
     with json_path.open('wt') as fh:

--- a/bakta/io/json.py
+++ b/bakta/io/json.py
@@ -37,6 +37,7 @@ def write_json(data: dict, features: Sequence[dict], json_path: Path):
         'version': f"{cfg.db_info['major']}.{cfg.db_info['minor']}",
         'type': cfg.db_info['type']
     }
+    version['amrfinderplus_db'] = cfg.amrfinderplus_db_version if cfg.amrfinderplus_db_version else None
     data['version'] = version
 
     with json_path.open('wt') as fh:

--- a/bakta/io/tsv.py
+++ b/bakta/io/tsv.py
@@ -25,6 +25,8 @@ def write_features(sequences: Sequence[dict], features_by_sequence: Dict[str, di
         fh.write('# Annotated with Bakta\n')
         fh.write(f'# Software: v{cfg.version}\n')
         fh.write(f"# Database: v{cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}\n")
+        if cfg.amrfinderplus_db_version:
+            fh.write(f'# AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
         fh.write(f'# DOI: {bc.BAKTA_DOI}\n')
         fh.write(f'# URL: {bc.BAKTA_URL}\n')
         fh.write('#Sequence Id\tType\tStart\tStop\tStrand\tLocus Tag\tGene\tProduct\tDbXrefs\n')
@@ -85,6 +87,8 @@ def write_feature_inferences(sequences: Sequence[dict], features_by_sequence: Di
         fh.write('# Annotated with Bakta\n')
         fh.write(f'# Software: v{cfg.version}\n')
         fh.write(f"# Database: v{cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}\n")
+        if cfg.amrfinderplus_db_version:
+            fh.write(f'# AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
         fh.write(f'# DOI: {bc.BAKTA_DOI}\n')
         fh.write(f'# URL: {bc.BAKTA_URL}\n')
         fh.write('#Sequence Id\tType\tStart\tStop\tStrand\tLocus Tag\tScore\tEvalue\tQuery Cov\tSubject Cov\tId\tAccession\n')

--- a/bakta/io/tsv.py
+++ b/bakta/io/tsv.py
@@ -25,8 +25,7 @@ def write_features(sequences: Sequence[dict], features_by_sequence: Dict[str, di
         fh.write('# Annotated with Bakta\n')
         fh.write(f'# Software: v{cfg.version}\n')
         fh.write(f"# Database: v{cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}\n")
-        if cfg.amrfinderplus_db_version:
-            fh.write(f'# AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
+        fh.write(f'# AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
         fh.write(f'# DOI: {bc.BAKTA_DOI}\n')
         fh.write(f'# URL: {bc.BAKTA_URL}\n')
         fh.write('#Sequence Id\tType\tStart\tStop\tStrand\tLocus Tag\tGene\tProduct\tDbXrefs\n')
@@ -87,8 +86,7 @@ def write_feature_inferences(sequences: Sequence[dict], features_by_sequence: Di
         fh.write('# Annotated with Bakta\n')
         fh.write(f'# Software: v{cfg.version}\n')
         fh.write(f"# Database: v{cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}\n")
-        if cfg.amrfinderplus_db_version:
-            fh.write(f'# AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
+        fh.write(f'# AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
         fh.write(f'# DOI: {bc.BAKTA_DOI}\n')
         fh.write(f'# URL: {bc.BAKTA_URL}\n')
         fh.write('#Sequence Id\tType\tStart\tStop\tStrand\tLocus Tag\tScore\tEvalue\tQuery Cov\tSubject Cov\tId\tAccession\n')

--- a/bakta/json_io.py
+++ b/bakta/json_io.py
@@ -109,6 +109,7 @@ def main():
         'major': data['version']['db']['version'].split('.')[0],
         'minor': data['version']['db']['version'].split('.')[1]
     }
+    cfg.amrfinderplus_db_version = data['version'].get('amrfinderplus_db', None)
     cfg.translation_table = data['genome']['translation_table']
     cfg.run_start = datetime.strptime(data['run']['start'], '%Y-%m-%d %H:%M:%S')
     cfg.run_end = datetime.strptime(data['run']['end'], '%Y-%m-%d %H:%M:%S')
@@ -193,6 +194,7 @@ def main():
         fh_out.write('\nBakta:\n')
         fh_out.write(f'Software: v{cfg.version}\n')
         fh_out.write(f"Database: v{cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}\n")
+        fh_out.write(f'AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
         fh_out.write('DOI: 10.1099/mgen.0.000685\n')
         fh_out.write('URL: github.com/oschwengers/bakta\n')
 

--- a/bakta/main.py
+++ b/bakta/main.py
@@ -62,6 +62,7 @@ def main():
         print('Options and arguments:')
         print(f'\tinput: {cfg.genome_path}')
         print(f"\tdb: {cfg.db_path}, version {cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}")
+        if cfg.amrfinderplus_db_path: print(f'\tamrfinderplus db: {cfg.amrfinderplus_db_path}, version {cfg.amrfinderplus_db_version}')
         if(cfg.replicons): print(f'\treplicon table: {cfg.replicons}')
         if(cfg.prodigal_tf): print(f'\tprodigal training file: {cfg.prodigal_tf}')
         if(cfg.regions): print(f'\tregion table: {cfg.regions}')

--- a/bakta/main.py
+++ b/bakta/main.py
@@ -62,7 +62,7 @@ def main():
         print('Options and arguments:')
         print(f'\tinput: {cfg.genome_path}')
         print(f"\tdb: {cfg.db_path}, version {cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}")
-        if cfg.amrfinderplus_db_path: print(f'\tamrfinderplus db: {cfg.amrfinderplus_db_path}, version {cfg.amrfinderplus_db_version}')
+        print(f'\tamrfinderplus db: {cfg.amrfinderplus_db_path}, version {cfg.amrfinderplus_db_version}')
         if(cfg.replicons): print(f'\treplicon table: {cfg.replicons}')
         if(cfg.prodigal_tf): print(f'\tprodigal training file: {cfg.prodigal_tf}')
         if(cfg.regions): print(f'\tregion table: {cfg.regions}')
@@ -626,6 +626,7 @@ def main():
         fh_out.write('\nBakta:\n')
         fh_out.write(f'Software: v{cfg.version}\n')
         fh_out.write(f"Database: v{cfg.db_info['major']}.{cfg.db_info['minor']}, {cfg.db_info['type']}\n")
+        fh_out.write(f'AMRFinderPlus database: {cfg.amrfinderplus_db_version}\n')
         fh_out.write('DOI: 10.1099/mgen.0.000685\n')
         fh_out.write('URL: github.com/oschwengers/bakta\n')
 

--- a/bakta/proteins.py
+++ b/bakta/proteins.py
@@ -37,6 +37,7 @@ def main():
     
     arg_group_io = parser.add_argument_group('Input / Output')
     arg_group_io.add_argument('--db', '-d', action='store', default=None, help='Database path (default = <bakta_path>/db). Can also be provided as BAKTA_DB environment variable.')
+    arg_group_io.add_argument('--amrfinder-db', action='store', default='latest', dest='amrfinder_db', help='AMRFinderPlus database version to use (default = latest). Value must correspond to a folder name in the amrfinderplus-db directory (e.g. 2023-11-15.1, latest).')
     arg_group_io.add_argument('--output', '-o', action='store', default=os.getcwd(), help='Output directory (default = current working directory)')
     arg_group_io.add_argument('--prefix', '-p', action='store', default=None, help='Prefix for output files')
     arg_group_io.add_argument('--force', '-f', action='store_true', help='Force overwriting existing output folder')
@@ -85,6 +86,7 @@ def main():
     
     cfg.check_db_path(args)
     cfg.db_info = db.check(cfg.db_path)
+    cfg.check_amrfinderplus_db(args)
     cfg.check_tmp_path(args)
     cfg.check_user_proteins(args)
     cfg.check_threads(args)

--- a/bakta/utils.py
+++ b/bakta/utils.py
@@ -72,6 +72,7 @@ def parse_arguments():
 
     arg_group_io = parser.add_argument_group('Input / Output')
     arg_group_io.add_argument('--db', '-d', action='store', default=None, help='Database path (default = <bakta_path>/db). Can also be provided as BAKTA_DB environment variable.')
+    arg_group_io.add_argument('--amrfinder-db', action='store', default='latest', dest='amrfinder_db', help='AMRFinderPlus database version to use (default = latest). Value must correspond to a folder name in the amrfinderplus-db directory (e.g. 2023-11-15.1, latest).')
     arg_group_io.add_argument('--min-contig-length', '-m', action='store', type=int, default=1, dest='min_contig_length', help='Minimum contig/sequence size (default = 1; 200 in compliant mode)')
     arg_group_io.add_argument('--prefix', '-p', action='store', default=None, help='Prefix for output files')
     arg_group_io.add_argument('--output', '-o', action='store', default=os.getcwd(), help='Output directory (default = current working directory)')
@@ -242,12 +243,11 @@ def test_dependencies():
 
         # test if AMRFinderPlus db is installed
         amrfinderplus_db_path = cfg.db_path.joinpath('amrfinderplus-db')
-        amrfinderplus_db_latest_path = amrfinderplus_db_path.joinpath('latest')
         process = sp.run(
             [
                 'amrfinder',
                 '--debug',
-                '--database', str(amrfinderplus_db_latest_path)
+                '--database', str(cfg.amrfinderplus_db_path)
             ], capture_output=True)
         if('No valid AMRFinder database found' in process.stderr.decode()):
             log.error('AMRFinderPlus database not installed')

--- a/test/test_args.py
+++ b/test/test_args.py
@@ -127,6 +127,42 @@ def test_database_ok(db, tmpdir):
     assert proc.returncode == 0
 
 
+@pytest.mark.parametrize(
+    'parameters',
+    [
+        (['--amrfinder-db', 'nonexistent-version']),  # non-existing version
+    ]
+)
+def test_amrfinder_db_failing_parameter(parameters, tmpdir):
+    # test --amrfinder-db arguments
+    proc = run(
+        ['bin/bakta', '--db', 'test/db', '--output', tmpdir, '--force', '--skip-plot'] +
+        parameters +
+        SKIP_PARAMETERS +
+        ['test/data/NC_002127.1.fna']
+    )
+    assert proc.returncode != 0
+
+
+@pytest.mark.parametrize(
+    'parameters',
+    [
+        ([]),  # default (latest)
+        (['--amrfinder-db', 'latest']),  # explicit latest
+        (['--amrfinder-db', '2025-12-03.1']),  # specific version
+    ]
+)
+def test_amrfinder_db_ok(parameters, tmpdir):
+    # test --amrfinder-db arguments
+    proc = run(
+        ['bin/bakta', '--db', 'test/db', '--output', tmpdir, '--force', '--skip-plot'] +
+        parameters +
+        SKIP_PARAMETERS +
+        ['test/data/NC_002127.1.fna']
+    )
+    assert proc.returncode == 0
+
+
 def test_output_failing():
     # test database arguments
     proc = run(


### PR DESCRIPTION
This PR is proposing a fix to enhance current amrfinder db selection and logging.

Previous behavior:

- bakta db on zenodo is bundled with specfic amrfinder db version. For example, bakta db v6 comes with amrfinder db 2024-12-18.1.
- bakta db download or update command will get the latest version of amrfinder db.
- Therefore, effectively the amrfinder db version in bakta db is not deterministic. As new amrfinder db becmoes available, the same bakta run may give different results, even given the same bakta db version, since bakta uses the latest amrfinder db version.
- While bakta db version is logged in several output files, amrfinder db version is not. This reduces reproducibility.

Proposed change:

- A cli argument is added for explicit amrfinder db selection (default to "latest" for consistent behavior as current implmenetation).
- amrfinder db version will be logged to output files. In case of "latest" amrfinder db being used, the actual version will be logged, instead of simply "latest".

bakta has been an essential tool for my research and it's been working great. I appreciate the efforts of the maintainers and developers.

Agent-Logs-Url: https://github.com/whatever60/bakta/sessions/840e31ce-9e17-4083-bfb0-0f9ea9101c81

Co-authored-by: whatever60 <57242693+whatever60@users.noreply.github.com>