### PR TITLE
reduce time complexity in get_adjacent_genes

### DIFF
--- a/bakta/features/annotation.py
+++ b/bakta/features/annotation.py
@@ -643,33 +643,34 @@ def mark_as_hypothetical(feature: dict):
     feature['product'] = bc.HYPOTHETICAL_PROTEIN
 
 
-def get_adjacent_genes(feature: dict, features: Sequence[dict], neighbors=3):
-    for idx, feat in enumerate(features):
-        if feat['locus'] == feature['locus']:
-            upstream_genes = []
-            if(idx >= 1):
-                start = idx - neighbors
-                if(start < 0 ):
-                    start = 0
-                upstream_genes = features[start:idx]
-            downstream_genes = []
-            if(idx + 1 < len(features)):
-                end = idx + 1 + neighbors
-                if(end > len(features)):
-                    end = len(features)
-                downstream_genes = features[idx+1:end]
-            upstream_genes.extend(downstream_genes)
-            for gene in upstream_genes:
-                log.debug(
-                    'extracted neighbor genes: seq=%s, start=%i, stop=%i, gene=%s, product=%s',
-                    gene['sequence'], gene['start'], gene['stop'], gene.get('gene', '-'), gene.get('product', '-')
-                )
-            return upstream_genes
-    return []
+def get_adjacent_genes(feature: dict, features: Sequence[dict], locus_index: dict, neighbors=3):
+    idx = locus_index.get(feature['locus'])
+    if idx is None:
+        return []
+    upstream_genes = []
+    if(idx >= 1):
+        start = idx - neighbors
+        if(start < 0 ):
+            start = 0
+        upstream_genes = features[start:idx]
+    downstream_genes = []
+    if(idx + 1 < len(features)):
+        end = idx + 1 + neighbors
+        if(end > len(features)):
+            end = len(features)
+        downstream_genes = features[idx+1:end]
+    upstream_genes.extend(downstream_genes)
+    for gene in upstream_genes:
+        log.debug(
+            'extracted neighbor genes: seq=%s, start=%i, stop=%i, gene=%s, product=%s',
+            gene['sequence'], gene['start'], gene['stop'], gene.get('gene', '-'), gene.get('product', '-')
+        )
+    return upstream_genes
 
 
 def select_gene_symbols(features: Sequence[dict]):
     improved_genes = []
+    locus_index = {feat['locus']: idx for idx, feat in enumerate(features)}
     for feat in [f for f in features if len(f.get('genes', [])) > 1]:  # all CDS/sORF with multiple gene symbols
         old_gene_symbol = feat['gene']
         gene_symbol_prefixes = set([symbol[:3] for symbol in feat['genes'] if len(symbol) > 3])
@@ -690,7 +691,7 @@ def select_gene_symbols(features: Sequence[dict]):
                 'select gene symbol: seq=%s, start=%i, stop=%i, gene=%s, genes=%s, product=%s',
                 feat['sequence'], feat['start'], feat['stop'], feat.get('gene', '-'), ','.join(feat['genes']), feat.get('product', '-')
             )
-            adjacent_genes = get_adjacent_genes(feat, features, neighbors=3)
+            adjacent_genes = get_adjacent_genes(feat, features, locus_index, neighbors=3)
             adjacent_gene_symbol_lists = [gene.get('genes', []) for gene in adjacent_genes]
             adjacent_gene_symbols = [item for sublist in adjacent_gene_symbol_lists for item in sublist]  # flatten lists
             adjacent_gene_symbol_prefixes = [gene_symbol[:3] for gene_symbol in adjacent_gene_symbols if len(gene_symbol) > 3]  # extract gene symbol prefixes, e.g. tra for traI, traX, traM


### PR DESCRIPTION
I profiled bakta again and found similar quick performance fix.

We can precompute a locus -> index map and pass it to get_adjacent_genes. Changes O(n) scan for a O(1) dict lookup. But we add additional param to get_adjacent_genes.

Tests were done on human gut metagenome samples assembled with megahit and using bakta v1.12.1 and full DB v6.0. See table below for performance change:

| sample | total time | get_adjacent_genes before | get_adjacent_genes after | saved | end-to-end speedup |
|---|---|---|---|---|---|
| ERR4333936 | 1,599 s → 1,540 s | 59.1 s | 0.20 s | 58.9 s | 1.038x |
| ERR4341823 | 1,749 s → 1,656 s | 94.2 s | 0.24 s | 94.0 s | 1.057x |
| ERR3607267 | 1,890 s → 1,800 s | 98.8 s | 0.25 s | 98.6 s | 1.055x |

Measured on m8a.4xlarge vm with 16 threads. Output is not affected, most diff is for indent change, bakta test suite passes. Used `--meta` flag.