### PR TITLE
perf(predict_t_rnas): chunk the input across tRNAscan-SE processes #289

### DIFF
--- a/bakta/features/t_rna.py
+++ b/bakta/features/t_rna.py
@@ -46,21 +46,6 @@ AMINO_ACID_DICT = {
 }
 
 
-def split_sequences(sequences: Sequence[dict], no_chunks: int) -> Sequence[Sequence[dict]]:
-    """Split sequences into chunks of roughly equal size, keeping their order."""
-    target = sum([seq['length'] for seq in sequences]) / no_chunks
-    split, chunk, size = [], [], 0
-    for seq in sequences:
-        chunk.append(seq)
-        size += seq['length']
-        if(size >= target and len(split) < no_chunks - 1):
-            split.append(chunk)
-            chunk, size = [], 0
-    if(len(chunk) > 0):
-        split.append(chunk)
-    return split
-
-
 def run_trnascan(cmd: Sequence[str]):
     """Run one tRNAscan-SE process."""
     return sp.run(
@@ -73,23 +58,13 @@ def run_trnascan(cmd: Sequence[str]):
     )
 
 
-def concat(parts: Sequence[Path], path: Path, skip: int=0):
-    """Concatenate tool output files in order, keeping one copy of the header."""
-    with path.open('wt') as fh_out:
-        for i, part in enumerate(parts):
-            with part.open() as fh_in:
-                for j, line in enumerate(fh_in):
-                    if(i == 0 or j >= skip):
-                        fh_out.write(line)
-
-
 def predict_t_rnas(data: dict, sequences_path: Path):
     """Search for tRNA sequences."""
 
     txt_output_path = cfg.tmp_path.joinpath('trna.tsv')
     fasta_output_path = cfg.tmp_path.joinpath('trna.fasta')
     no_chunks = min(cfg.threads, len(data['sequences']))
-    chunks = split_sequences(data['sequences'], no_chunks)
+    chunks = fasta.split_sequences(data['sequences'], no_chunks)
     cmds, txt_paths, fasta_paths = [], [], []
     for i, chunk in enumerate(chunks):
         txt_paths.append(cfg.tmp_path.joinpath(f'trna.{i}.tsv'))
@@ -114,8 +89,8 @@ def predict_t_rnas(data: dict, sequences_path: Path):
             log.debug('stdout=\'%s\', stderr=\'%s\'', proc.stdout, proc.stderr)
             log.warning('tRNAs failed! tRNAscan-SE-error-code=%d', proc.returncode)
             raise Exception(f'tRNAscan-SE error! error code: {proc.returncode}')
-    concat(txt_paths, txt_output_path, skip=3)
-    concat(fasta_paths, fasta_output_path)
+    fasta.concat(txt_paths, txt_output_path, skip=3)
+    fasta.concat(fasta_paths, fasta_output_path)
 
     trnas = {}
     sequences = {seq['id']: seq for seq in data['sequences']}

--- a/bakta/features/t_rna.py
+++ b/bakta/features/t_rna.py
@@ -64,6 +64,7 @@ def predict_t_rnas(data: dict, sequences_path: Path):
     txt_output_path = cfg.tmp_path.joinpath('trna.tsv')
     fasta_output_path = cfg.tmp_path.joinpath('trna.fasta')
     no_chunks = min(cfg.threads, len(data['sequences']))
+    threads = cfg.threads if no_chunks == 1 else 0
     chunks = fasta.split_sequences(data['sequences'], no_chunks)
     cmds, txt_paths, fasta_paths = [], [], []
     for i, chunk in enumerate(chunks):
@@ -78,7 +79,7 @@ def predict_t_rnas(data: dict, sequences_path: Path):
             '-B',
             '--output', str(txt_paths[i]),
             '--fasta', str(fasta_paths[i]),
-            '--thread', '0',
+            '--thread', str(threads),
             str(chunk_path)
         ])
     log.debug('cmds=%s', cmds)

--- a/bakta/features/t_rna.py
+++ b/bakta/features/t_rna.py
@@ -1,5 +1,4 @@
 import logging
-import subprocess as sp
 
 from concurrent.futures import ThreadPoolExecutor
 
@@ -46,18 +45,6 @@ AMINO_ACID_DICT = {
 }
 
 
-def run_trnascan(cmd: Sequence[str]):
-    """Run one tRNAscan-SE process."""
-    return sp.run(
-        cmd,
-        cwd=str(cfg.tmp_path),
-        env=cfg.env,
-        stdout=sp.PIPE,
-        stderr=sp.PIPE,
-        universal_newlines=True
-    )
-
-
 def predict_t_rnas(data: dict, sequences_path: Path):
     """Search for tRNA sequences."""
 
@@ -66,9 +53,9 @@ def predict_t_rnas(data: dict, sequences_path: Path):
     no_chunks = min(cfg.threads, len(data['sequences']))
     threads = cfg.threads if no_chunks == 1 else 0
     chunks = fasta.split_sequences(data['sequences'], no_chunks)
-    cmds, txt_paths, fasta_paths = [], [], []
+    cmds, tsv_paths, fasta_paths = [], [], []
     for i, chunk in enumerate(chunks):
-        txt_paths.append(cfg.tmp_path.joinpath(f'trna.{i}.tsv'))
+        tsv_paths.append(cfg.tmp_path.joinpath(f'trna.{i}.tsv'))
         fasta_paths.append(cfg.tmp_path.joinpath(f'trna.{i}.fasta'))
         chunk_path = sequences_path
         if(no_chunks > 1):
@@ -77,20 +64,20 @@ def predict_t_rnas(data: dict, sequences_path: Path):
         cmds.append([
             'tRNAscan-SE',
             '-B',
-            '--output', str(txt_paths[i]),
+            '--output', str(tsv_paths[i]),
             '--fasta', str(fasta_paths[i]),
             '--thread', str(threads),
             str(chunk_path)
         ])
     log.debug('cmds=%s', cmds)
     with ThreadPoolExecutor(max_workers=len(cmds)) as tpe:
-        procs = list(tpe.map(run_trnascan, cmds))
+        procs = list(tpe.map(bu.run_tool, cmds))
     for proc in procs:
         if(proc.returncode != 0):
             log.debug('stdout=\'%s\', stderr=\'%s\'', proc.stdout, proc.stderr)
             log.warning('tRNAs failed! tRNAscan-SE-error-code=%d', proc.returncode)
             raise Exception(f'tRNAscan-SE error! error code: {proc.returncode}')
-    fasta.concat(txt_paths, txt_output_path, skip=3)
+    fasta.concat(tsv_paths, txt_output_path, skip=3)
     fasta.concat(fasta_paths, fasta_output_path)
 
     trnas = {}

--- a/bakta/features/t_rna.py
+++ b/bakta/features/t_rna.py
@@ -1,13 +1,17 @@
 import logging
 import subprocess as sp
 
+from concurrent.futures import ThreadPoolExecutor
+
 from collections import OrderedDict
 from pathlib import Path
+from typing import Sequence
 
 from Bio import SeqIO
 
 import bakta.config as cfg
 import bakta.constants as bc
+import bakta.io.fasta as fasta
 import bakta.so as so
 import bakta.utils as bu
 
@@ -42,21 +46,24 @@ AMINO_ACID_DICT = {
 }
 
 
-def predict_t_rnas(data: dict, sequences_path: Path):
-    """Search for tRNA sequences."""
+def split_sequences(sequences: Sequence[dict], no_chunks: int) -> Sequence[Sequence[dict]]:
+    """Split sequences into chunks of roughly equal size, keeping their order."""
+    target = sum([seq['length'] for seq in sequences]) / no_chunks
+    split, chunk, size = [], [], 0
+    for seq in sequences:
+        chunk.append(seq)
+        size += seq['length']
+        if(size >= target and len(split) < no_chunks - 1):
+            split.append(chunk)
+            chunk, size = [], 0
+    if(len(chunk) > 0):
+        split.append(chunk)
+    return split
 
-    txt_output_path = cfg.tmp_path.joinpath('trna.tsv')
-    fasta_output_path = cfg.tmp_path.joinpath('trna.fasta')
-    cmd = [
-        'tRNAscan-SE',
-        '-B',
-        '--output', str(txt_output_path),
-        '--fasta', str(fasta_output_path),
-        '--thread', str(cfg.threads),
-        str(sequences_path)
-    ]
-    log.debug('cmd=%s', cmd)
-    proc = sp.run(
+
+def run_trnascan(cmd: Sequence[str]):
+    """Run one tRNAscan-SE process."""
+    return sp.run(
         cmd,
         cwd=str(cfg.tmp_path),
         env=cfg.env,
@@ -64,10 +71,51 @@ def predict_t_rnas(data: dict, sequences_path: Path):
         stderr=sp.PIPE,
         universal_newlines=True
     )
-    if(proc.returncode != 0):
-        log.debug('stdout=\'%s\', stderr=\'%s\'', proc.stdout, proc.stderr)
-        log.warning('tRNAs failed! tRNAscan-SE-error-code=%d', proc.returncode)
-        raise Exception(f'tRNAscan-SE error! error code: {proc.returncode}')
+
+
+def concat(parts: Sequence[Path], path: Path, skip: int=0):
+    """Concatenate tool output files in order, keeping one copy of the header."""
+    with path.open('wt') as fh_out:
+        for i, part in enumerate(parts):
+            with part.open() as fh_in:
+                for j, line in enumerate(fh_in):
+                    if(i == 0 or j >= skip):
+                        fh_out.write(line)
+
+
+def predict_t_rnas(data: dict, sequences_path: Path):
+    """Search for tRNA sequences."""
+
+    txt_output_path = cfg.tmp_path.joinpath('trna.tsv')
+    fasta_output_path = cfg.tmp_path.joinpath('trna.fasta')
+    no_chunks = min(cfg.threads, len(data['sequences']))
+    chunks = split_sequences(data['sequences'], no_chunks)
+    cmds, txt_paths, fasta_paths = [], [], []
+    for i, chunk in enumerate(chunks):
+        txt_paths.append(cfg.tmp_path.joinpath(f'trna.{i}.tsv'))
+        fasta_paths.append(cfg.tmp_path.joinpath(f'trna.{i}.fasta'))
+        chunk_path = sequences_path
+        if(no_chunks > 1):
+            chunk_path = cfg.tmp_path.joinpath(f'trna.{i}.fna')
+            fasta.export_sequences(chunk, chunk_path)
+        cmds.append([
+            'tRNAscan-SE',
+            '-B',
+            '--output', str(txt_paths[i]),
+            '--fasta', str(fasta_paths[i]),
+            '--thread', '0',
+            str(chunk_path)
+        ])
+    log.debug('cmds=%s', cmds)
+    with ThreadPoolExecutor(max_workers=len(cmds)) as tpe:
+        procs = list(tpe.map(run_trnascan, cmds))
+    for proc in procs:
+        if(proc.returncode != 0):
+            log.debug('stdout=\'%s\', stderr=\'%s\'', proc.stdout, proc.stderr)
+            log.warning('tRNAs failed! tRNAscan-SE-error-code=%d', proc.returncode)
+            raise Exception(f'tRNAscan-SE error! error code: {proc.returncode}')
+    concat(txt_paths, txt_output_path, skip=3)
+    concat(fasta_paths, fasta_output_path)
 
     trnas = {}
     sequences = {seq['id']: seq for seq in data['sequences']}

--- a/bakta/io/fasta.py
+++ b/bakta/io/fasta.py
@@ -76,6 +76,31 @@ def export_sequences(sequences: Sequence[dict], fasta_path: Path, description: b
                 fh.write('\n')
 
 
+def split_sequences(sequences: Sequence[dict], no_chunks: int) -> Sequence[Sequence[dict]]:
+    """Split sequences into chunks of roughly equal size, keeping their order."""
+    target = sum([seq['length'] for seq in sequences]) / no_chunks
+    split, chunk, size = [], [], 0
+    for seq in sequences:
+        chunk.append(seq)
+        size += seq['length']
+        if(size >= target and len(split) < no_chunks - 1):
+            split.append(chunk)
+            chunk, size = [], 0
+    if(len(chunk) > 0):
+        split.append(chunk)
+    return split
+
+
+def concat(parts: Sequence[Path], path: Path, skip: int=0):
+    """Concatenate tool output files in order, keeping one copy of the header."""
+    with path.open('wt') as fh_out:
+        for i, part in enumerate(parts):
+            with part.open() as fh_in:
+                for j, line in enumerate(fh_in):
+                    if(i == 0 or j >= skip):
+                        fh_out.write(line)
+
+
 def wrap_sequence(sequence: str):
     lines = []
     for i in range(0, len(sequence), FASTA_LINE_WRAPPING):

--- a/bakta/utils.py
+++ b/bakta/utils.py
@@ -209,6 +209,18 @@ def check_version(tool, min: int, max:int ) -> bool:
             return True
 
 
+def run_tool(cmd: Sequence[str]):
+    """Run one external tool process."""
+    return sp.run(
+        cmd,
+        cwd=str(cfg.tmp_path),
+        env=cfg.env,
+        stdout=sp.PIPE,
+        stderr=sp.PIPE,
+        universal_newlines=True
+    )
+
+
 def test_dependency(dependency):
     """Test the proper installation of the required 3rd party executable."""
     version = read_tool_output(dependency)


### PR DESCRIPTION
Following #289 and `predict_t_rnas` performance.

Currently bakta passes cfg.threads to tRNAscan-SE and for metagenomes it is inefficient and reason behind #289 reported performance. Running on single core is much faster for this type of input.

As author in #289 proposed we can split the input into chunks and run one tRNAscan-SE process per chunk with `--thread 0`, so the parallelism comes from the processes. I explored some other possibilities, but this is the best approach currently. This is necessary to run on assemblies from e.g. 2GB FASTQ.gz efficiently.

"Why not run at `--threads 1`? Because at `--cpu 0` cmsearch takes its serial path and never builds the thread pool or the work queue. At `--cpu 1` it builds both to run a single worker, and that setup is paid on every invocation - two per contig. The difference is 0 to 8% for identical output" - AI summary, worth checking out but performance increase is real.

I adapted to current code style. Output is identical — chunks keep input order, are concatenated in order, and I compared the feature list against an unpatched run on many samples. Bakta tests pass. On a single-contig no_chunks = 1 so here logic is the same. For 2-3 contigs you could use hybrid approach e.g. 3 chunks each with 5 cores but i went with simpler approach and the difference is not that meaningful. With more contigs chunking wins.
Peak RSS is not meaningfully higher.

I measured the fix on multiple samples of different size and type. 

| sample | contigs | --thread 15 (current) | --thread 0 | --thread 1 | chunked, 15 cores (proposed) | vs current | vs --thread 0 | efficiency* (prop) | cpu_efficiency** (prop) | peak_RSS (thr0 vs prop) |
|---|---|---|---|---|---|---|---|---|---|---|
| ERR4333936 | 95,607 | 4,384.0 s | 1,785.3 s | - | 137.2 s | 31.95x | 13.01x | 87% | 86% | 2,957 MB -> 3,258 MB |
| ERR4341823 | 210,201 | - | 3,145.6 s | - | 233.9 s | - | 13.45x | 90% | 81% | 3,831 MB -> 4,189 MB |
| ERR3607267 | 252,200 | - | 3,510.5 s | 3,694.8 s | 256.2 s | - | 13.70x | 91% | 88% | 4,138 MB -> 4,563 MB |
| E. coli | 1 | 7.7 s | 19.5 s | 19.6 s | 7.7 s | 1.00x | 2.53x | 17% | 16% | 212 MB -> 379 MB |

\* efficiency = (--thread 0 / chunked) / 15 cores
\*\* cpu_efficiency = mean cores busy / 15 cores allocated, from cgroups

Tests were done on human gut metagenome samples assembled with megahit and bakta v1.12.1 and full DB v6.0. Measured on m8a.4xlarge vm with 15 threads. Worked on bakta reduced to relevant part (--skip-* flags).

Added split/merge functions to fasta.py file, r_rna, nc_rna, nc_rna-regions will use the same function and approach - i measured similar performance benefit but thats for another PR.

Don't mind me while on vacation :D, enjoy your time off.
